### PR TITLE
Add PanamaVectorSupport for Java 20+

### DIFF
--- a/src/main/java/com/github/jbellis/jvector/vector/PanamaVectorUtilSupport.java
+++ b/src/main/java/com/github/jbellis/jvector/vector/PanamaVectorUtilSupport.java
@@ -1,0 +1,40 @@
+package com.github.jbellis.jvector.vector;
+
+final class PanamaVectorUtilSupport implements VectorUtilSupport {
+
+    @Override
+    public float dotProduct(float[] a, float[] b)
+    {
+        return SimdOps.dotProduct(a, b);
+    }
+
+    @Override
+    public float cosine(float[] v1, float[] v2)
+    {
+        return SimdOps.cosineSimilarity(v1, v2);
+    }
+
+    @Override
+    public float squareDistance(float[] a, float[] b)
+    {
+        return SimdOps.squareDistance(a, b);
+    }
+
+    @Override
+    public int dotProduct(byte[] a, byte[] b)
+    {
+        return SimdOps.dotProduct(a, b);
+    }
+
+    @Override
+    public float cosine(byte[] a, byte[] b)
+    {
+        return SimdOps.cosineSimilarity(a, b);
+    }
+
+    @Override
+    public int squareDistance(byte[] a, byte[] b)
+    {
+        return SimdOps.squareDistance(a, b);
+    }
+}

--- a/src/main/java/com/github/jbellis/jvector/vector/PanamaVectorizationProvider.java
+++ b/src/main/java/com/github/jbellis/jvector/vector/PanamaVectorizationProvider.java
@@ -1,0 +1,16 @@
+package com.github.jbellis.jvector.vector;
+
+public class PanamaVectorizationProvider extends VectorizationProvider {
+
+    private final VectorUtilSupport vectorUtilSupport;
+
+    public PanamaVectorizationProvider() {
+        this.vectorUtilSupport = new PanamaVectorUtilSupport();
+    }
+
+    @Override
+    public VectorUtilSupport getVectorUtilSupport()
+    {
+        return vectorUtilSupport;
+    }
+}

--- a/src/main/java/com/github/jbellis/jvector/vector/SimdOps.java
+++ b/src/main/java/com/github/jbellis/jvector/vector/SimdOps.java
@@ -7,9 +7,6 @@ import jdk.incubator.vector.VectorOperators;
 
 import java.util.List;
 
-import static jdk.incubator.vector.VectorOperators.B2I;
-import static jdk.incubator.vector.VectorOperators.ZERO_EXTEND_B2I;
-
 public class SimdOps {
     public static float simdSum(float[] vector) {
         float sum = 0.0f;

--- a/src/main/java/com/github/jbellis/jvector/vector/SimdOps.java
+++ b/src/main/java/com/github/jbellis/jvector/vector/SimdOps.java
@@ -1,9 +1,14 @@
 package com.github.jbellis.jvector.vector;
 
+import jdk.incubator.vector.ByteVector;
 import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.IntVector;
 import jdk.incubator.vector.VectorOperators;
 
 import java.util.List;
+
+import static jdk.incubator.vector.VectorOperators.B2I;
+import static jdk.incubator.vector.VectorOperators.ZERO_EXTEND_B2I;
 
 public class SimdOps {
     public static float simdSum(float[] vector) {
@@ -92,6 +97,174 @@ public class SimdOps {
         var b = FloatVector.fromArray(FloatVector.SPECIES_64, v2, offset2);
         var multiplyResult = a.mul(b);
         return multiplyResult.reduceLanes(VectorOperators.ADD);
+    }
+
+    public static float dotProduct(float[] v1, float[] v2) {
+        if (v1.length != v2.length) {
+            throw new IllegalArgumentException("Vectors must have the same length");
+        }
+        var sum = FloatVector.zero(FloatVector.SPECIES_PREFERRED);
+        int vectorizedLength = FloatVector.SPECIES_PREFERRED.loopBound(v1.length);
+
+        // Process the vectorized part
+        for (int i = 0; i < vectorizedLength; i += FloatVector.SPECIES_PREFERRED.length()) {
+            var a = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, v1, i);
+            var b = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, v2, i);
+            sum = sum.add(a.mul(b));
+        }
+
+        float res = sum.reduceLanes(VectorOperators.ADD);
+
+        // Process the tail
+        for (int i = vectorizedLength; i < v1.length; i++) {
+            res += v1[i] * v2[i];
+        }
+
+        return res;
+    }
+
+    public static int dotProduct(byte[] v1, byte[] v2) {
+        if (v1.length != v2.length) {
+            throw new IllegalArgumentException("Vectors must have the same length");
+        }
+        var sum = IntVector.zero(IntVector.SPECIES_256);
+        int vectorizedLength = ByteVector.SPECIES_64.loopBound(v1.length);
+
+        // Process the vectorized part, convert from 8 bytes to 8 ints
+        for (int i = 0; i < vectorizedLength; i += ByteVector.SPECIES_64.length()) {
+            var a = ByteVector.fromArray(ByteVector.SPECIES_64, v1, i).castShape(IntVector.SPECIES_256, 0);
+            var b = ByteVector.fromArray(ByteVector.SPECIES_64, v2, i).castShape(IntVector.SPECIES_256, 0);
+            sum = sum.add(a.mul(b));
+        }
+
+        int res = sum.reduceLanes(VectorOperators.ADD);
+
+        // Process the tail
+        for (int i = vectorizedLength; i < v1.length; i++) {
+            res += v1[i] * v2[i];
+        }
+
+        return res;
+    }
+
+    public static float cosineSimilarity(float[] v1, float[] v2) {
+        if (v1.length != v2.length) {
+            throw new IllegalArgumentException("Vectors must have the same length");
+        }
+
+        var vsum = FloatVector.zero(FloatVector.SPECIES_PREFERRED);
+        var vaMagnitude = FloatVector.zero(FloatVector.SPECIES_PREFERRED);
+        var vbMagnitude = FloatVector.zero(FloatVector.SPECIES_PREFERRED);
+
+        int vectorizedLength = FloatVector.SPECIES_PREFERRED.loopBound(v1.length);
+        // Process the vectorized part, convert from 8 bytes to 8 ints
+        for (int i = 0; i < vectorizedLength; i += FloatVector.SPECIES_PREFERRED.length()) {
+            var a = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, v1, i);
+            var b = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, v2, i);
+            vsum = vsum.add(a.mul(b));
+            vaMagnitude = vaMagnitude.add(a.mul(a));
+            vbMagnitude = vbMagnitude.add(b.mul(b));
+        }
+
+        float sum = vsum.reduceLanes(VectorOperators.ADD);
+        float aMagnitude = vaMagnitude.reduceLanes(VectorOperators.ADD);
+        float bMagnitude = vbMagnitude.reduceLanes(VectorOperators.ADD);
+
+        // Process the tail
+        for (int i = vectorizedLength; i < v1.length; i++) {
+            sum += v1[i] * v2[i];
+            aMagnitude += v1[i] * v1[i];
+            bMagnitude += v2[i] * v2[i];
+        }
+
+        return (float) (sum / Math.sqrt(aMagnitude * bMagnitude));
+    }
+
+    public static float cosineSimilarity(byte[] v1, byte[] v2) {
+        if (v1.length != v2.length) {
+            throw new IllegalArgumentException("Vectors must have the same length");
+        }
+
+        var vsum = IntVector.zero(IntVector.SPECIES_256);
+        var vaMagnitude = IntVector.zero(IntVector.SPECIES_256);
+        var vbMagnitude = IntVector.zero(IntVector.SPECIES_256);
+
+        int vectorizedLength = ByteVector.SPECIES_64.loopBound(v1.length);
+        // Process the vectorized part, convert from 8 bytes to 8 ints
+        for (int i = 0; i < vectorizedLength; i += ByteVector.SPECIES_64.length()) {
+            var a = ByteVector.fromArray(ByteVector.SPECIES_64, v1, i).castShape(IntVector.SPECIES_256, 0);
+            var b = ByteVector.fromArray(ByteVector.SPECIES_64, v2, i).castShape(IntVector.SPECIES_256, 0);
+            vsum = vsum.add(a.mul(b));
+            vaMagnitude = vaMagnitude.add(a.mul(a));
+            vbMagnitude = vbMagnitude.add(b.mul(b));
+        }
+
+        int sum = vsum.reduceLanes(VectorOperators.ADD);
+        int aMagnitude = vaMagnitude.reduceLanes(VectorOperators.ADD);
+        int bMagnitude = vbMagnitude.reduceLanes(VectorOperators.ADD);
+
+        // Process the tail
+        for (int i = vectorizedLength; i < v1.length; i++) {
+            sum += v1[i] * v2[i];
+            aMagnitude += v1[i] * v1[i];
+            bMagnitude += v2[i] * v2[i];
+        }
+
+        return (float) (sum / Math.sqrt(aMagnitude * bMagnitude));
+    }
+
+    public static float squareDistance(float[] v1, float[] v2) {
+        if (v1.length != v2.length) {
+            throw new IllegalArgumentException("Vectors must have the same length");
+        }
+
+        var vdiffSumSquared = FloatVector.zero(FloatVector.SPECIES_PREFERRED);
+
+        int vectorizedLength = FloatVector.SPECIES_PREFERRED.loopBound(v1.length);
+        // Process the vectorized part
+        for (int i = 0; i < vectorizedLength; i += FloatVector.SPECIES_PREFERRED.length()) {
+            var a = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, v1, i);
+            var b = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, v2, i);
+
+            var diff = a.sub(b);
+            vdiffSumSquared = vdiffSumSquared.add(diff.mul(diff));
+        }
+
+        float diffSumSquared = vdiffSumSquared.reduceLanes(VectorOperators.ADD);
+
+        // Process the tail
+        for (int i = vectorizedLength; i < v1.length; i++) {
+            diffSumSquared += (v1[i] - v2[i]) * (v1[i] - v2[i]);
+        }
+
+        return diffSumSquared;
+    }
+
+    public static int squareDistance(byte[] v1, byte[] v2) {
+        if (v1.length != v2.length) {
+            throw new IllegalArgumentException("Vectors must have the same length");
+        }
+
+        var vdiffSumSquared = IntVector.zero(IntVector.SPECIES_256);
+
+        int vectorizedLength = ByteVector.SPECIES_64.loopBound(v1.length);
+        // Process the vectorized part
+        for (int i = 0; i < vectorizedLength; i += ByteVector.SPECIES_64.length()) {
+            var a = ByteVector.fromArray(ByteVector.SPECIES_64, v1, i).castShape(IntVector.SPECIES_256, 0);
+            var b = ByteVector.fromArray(ByteVector.SPECIES_64, v2, i).castShape(IntVector.SPECIES_256, 0);
+
+            var diff = a.sub(b);
+            vdiffSumSquared = vdiffSumSquared.add(diff.mul(diff));
+        }
+
+        int diffSumSquared = vdiffSumSquared.reduceLanes(VectorOperators.ADD);
+
+        // Process the tail
+        for (int i = vectorizedLength; i < v1.length; i++) {
+            diffSumSquared += (v1[i] - v2[i]) * (v1[i] - v2[i]);
+        }
+
+        return diffSumSquared;
     }
 
     /**

--- a/src/test/java/com/github/jbellis/jvector/graph/GraphIndexTestCase.java
+++ b/src/test/java/com/github/jbellis/jvector/graph/GraphIndexTestCase.java
@@ -660,7 +660,7 @@ public abstract class GraphIndexTestCase<T> extends RandomizedTest {
     return bits;
   }
 
-  static float[] randomVector(Random random, int dim) {
+  public static float[] randomVector(Random random, int dim) {
     float[] vec = new float[dim];
     for (int i = 0; i < dim; i++) {
       vec[i] = random.nextFloat();
@@ -672,7 +672,7 @@ public abstract class GraphIndexTestCase<T> extends RandomizedTest {
     return vec;
   }
 
-  static byte[] randomVector8(Random random, int dim) {
+  public static byte[] randomVector8(Random random, int dim) {
     float[] fvec = randomVector(random, dim);
     byte[] bvec = new byte[dim];
     for (int i = 0; i < dim; i++) {

--- a/src/test/java/com/github/jbellis/jvector/vector/TestVectorizationProvider.java
+++ b/src/test/java/com/github/jbellis/jvector/vector/TestVectorizationProvider.java
@@ -1,0 +1,47 @@
+package com.github.jbellis.jvector.vector;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+import com.github.jbellis.jvector.graph.GraphIndexTestCase;
+
+public class TestVectorizationProvider {
+    static boolean hasSimd = VectorizationProvider.vectorModulePresentAndReadable();
+
+    @Test
+    public void testDotProductFloat() {
+        Assume.assumeTrue(hasSimd);
+
+        VectorizationProvider a = new DefaultVectorizationProvider();
+        VectorizationProvider b = new PanamaVectorizationProvider();
+
+        for (int i = 0; i < 1000; i++) {
+            float[] v1 = GraphIndexTestCase.randomVector(ThreadLocalRandom.current(), 1021); //prime numbers
+            float[] v2 = GraphIndexTestCase.randomVector(ThreadLocalRandom.current(), 1021); //prime numbers
+
+            Assert.assertEquals(a.getVectorUtilSupport().dotProduct(v1,v2), b.getVectorUtilSupport().dotProduct(v1, v2), 0.00001f);
+            Assert.assertEquals(a.getVectorUtilSupport().cosine(v1,v2), b.getVectorUtilSupport().cosine(v1, v2), 0.00001f);
+            Assert.assertEquals(a.getVectorUtilSupport().squareDistance(v1,v2), b.getVectorUtilSupport().squareDistance(v1, v2), 0.00001f);
+        }
+    }
+
+    @Test
+    public void testDotProductByte() {
+        Assume.assumeTrue(hasSimd);
+
+        VectorizationProvider a = new DefaultVectorizationProvider();
+        VectorizationProvider b = new PanamaVectorizationProvider();
+
+        for (int i = 0; i < 1000; i++) {
+            byte[] v1 = GraphIndexTestCase.randomVector8(ThreadLocalRandom.current(), 1021); //prime numbers
+            byte[] v2 = GraphIndexTestCase.randomVector8(ThreadLocalRandom.current(), 1021); //prime numbers
+
+            Assert.assertEquals(a.getVectorUtilSupport().dotProduct(v1,v2), b.getVectorUtilSupport().dotProduct(v1, v2));
+            Assert.assertEquals(a.getVectorUtilSupport().cosine(v1,v2), b.getVectorUtilSupport().cosine(v1, v2), 0.00001f);
+            Assert.assertEquals(a.getVectorUtilSupport().squareDistance(v1,v2), b.getVectorUtilSupport().squareDistance(v1, v2));
+        }
+    }
+}


### PR DESCRIPTION
Bench Demo without and with Panama:

```


hdf5/nytimes-256-angular.hdf5: 289761 base and 9991 query vectors loaded, dimensions 256
Index   M=8 ef=60: top 100/1 recall 0.4346, build 18.34s, query 5.89s. 94003210 nodes visited
Index   M=8 ef=60: top 100/2 recall 0.5334, build 18.34s, query 10.87s. 160716180 nodes visited
Index   M=8 ef=60: top 100/4 recall 0.6192, build 18.34s, query 18.91s. 284583030 nodes visited
Index   M=8 ef=80: top 100/1 recall 0.4919, build 21.89s, query 5.99s. 100470940 nodes visited
Index   M=8 ef=80: top 100/2 recall 0.5919, build 21.89s, query 10.84s. 170832280 nodes visited
Index   M=8 ef=80: top 100/4 recall 0.6703, build 21.89s, query 19.76s. 300788670 nodes visited


hdf5/nytimes-256-angular.hdf5: 289761 base and 9991 query vectors loaded, dimensions 256
Index   M=8 ef=60: top 100/1 recall 0.4329, build 13.71s, query 4.69s. 94820350 nodes visited
Index   M=8 ef=60: top 100/2 recall 0.5372, build 13.71s, query 7.91s. 162045080 nodes visited
Index   M=8 ef=60: top 100/4 recall 0.6198, build 13.71s, query 17.86s. 284537410 nodes visited
Index   M=8 ef=80: top 100/1 recall 0.4902, build 17.87s, query 4.87s. 100535070 nodes visited
Index   M=8 ef=80: top 100/2 recall 0.5905, build 17.87s, query 8.28s. 170687080 nodes visited
Index   M=8 ef=80: top 100/4 recall 0.6692, build 17.87s, query 15.51s. 300101490 nodes visited

```

