### PR TITLE
Issue 38 multiple jdk builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
+.java-version
 
 ### IntelliJ IDEA ###
 .idea

--- a/README.md
+++ b/README.md
@@ -21,3 +21,13 @@ To run either class, you can use the Maven exec-plugin via the following incanta
 ```mvn clean install exec:exec@bench``` 
 or for Sift:
 ```mvn clean install exec:exec@sift```
+
+To compile for a specific JDK, you can use the targeted execution defined in the pom:
+- `mvn clean compiler:compile@jdk11` for JDK 11
+- `mvn clean compiler:compile@jdk20` for JDK 20
+
+Similar to the compile executions, a JAR file can be generated via:
+- `mvn jar:jar@jar-jdk11` for JDK 11
+- `mvn jar:jar@jar-jdk20` for JDK 20
+
+In both cases, you must have invoked the compile target for that specific JDK, or the resulting jar file will be empty.  

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,6 @@
   <!-- Build property abstractions: versions, etc -->
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>20</maven.compiler.source>
-    <maven.compiler.target>20</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -70,12 +68,70 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.11.0</version>
         <configuration>
-          <enablePreview>true</enablePreview>
+          <source>20</source>
+          <target>20</target>
           <compilerArgs>
             <arg>--add-modules</arg>
             <arg>jdk.incubator.vector</arg>
           </compilerArgs>
         </configuration>
+        <executions>
+          <execution>
+            <id>jdk20</id>
+            <configuration>
+              <source>20</source>
+              <target>20</target>
+              <enablePreview>true</enablePreview>
+              <compilerArgs>
+                <arg>--add-modules</arg>
+                <arg>jdk.incubator.vector</arg>
+              </compilerArgs>
+              <outputDirectory>${project.build.outputDirectory}_jdk20</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>jdk11</id>
+            <configuration>
+              <excludes>
+                <exclude>com/github/jbellis/jvector/example/Bench.java</exclude>
+              </excludes>
+              <source>11</source>
+              <target>11</target>
+              <compilerArgs>
+                <arg>--add-modules</arg>
+                <arg>jdk.incubator.vector</arg>
+              </compilerArgs>
+              <outputDirectory>${project.build.outputDirectory}_jdk11</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>jar-jdk11</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>jdk11</classifier>
+              <classesDirectory>${project.build.outputDirectory}_jdk11</classesDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>jar-jdk20</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>jdk20</classifier>
+              <classesDirectory>${project.build.outputDirectory}_jdk20</classesDirectory>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Uses executions in both compile and jar tasks to do toggle which JVM is used. I most likely missed something, but the block and tackle stuff of compile and exec is working provided you follow the updated instructions in the readme. I'll add a section about how to reference the jar for the JDK version you want once I verify that with C*. 