### PR TITLE
read and write in little endian order

### DIFF
--- a/jvector-base/src/main/java/com/github/jbellis/jvector/disk/CompressedVectors.java
+++ b/jvector-base/src/main/java/com/github/jbellis/jvector/disk/CompressedVectors.java
@@ -37,6 +37,8 @@ public class CompressedVectors
 
     public void write(DataOutput out) throws IOException
     {
+        out = new LittleEndianDataOutput(out);
+
         // pq codebooks
         pq.write(out);
 

--- a/jvector-base/src/main/java/com/github/jbellis/jvector/disk/Io.java
+++ b/jvector-base/src/main/java/com/github/jbellis/jvector/disk/Io.java
@@ -16,7 +16,6 @@
 
 package com.github.jbellis.jvector.disk;
 
-import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
@@ -25,13 +24,5 @@ public class Io {
         for (var a : v) {
             out.writeFloat(a);
         }
-    }
-
-    public static float[] readFloats(DataInput in, int size) throws IOException {
-        var v = new float[size];
-        for (int i = 0; i < size; i++) {
-            v[i] = in.readFloat();
-        }
-        return v;
     }
 }

--- a/jvector-base/src/main/java/com/github/jbellis/jvector/disk/LittleEndianDataOutput.java
+++ b/jvector-base/src/main/java/com/github/jbellis/jvector/disk/LittleEndianDataOutput.java
@@ -1,0 +1,106 @@
+package com.github.jbellis.jvector.disk;
+
+import java.io.DataOutput;
+import java.io.IOException;
+
+public class LittleEndianDataOutput implements DataOutput {
+
+    private final DataOutput out;
+
+    /**
+     * Constructs a LittleEndianDataOutput that writes to the specified DataOutput in little-endian order.
+     *
+     * @param out the DataOutput stream
+     */
+    public LittleEndianDataOutput(DataOutput out) {
+        this.out = out;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        out.write(b);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        out.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        out.write(b, off, len);
+    }
+
+    @Override
+    public void writeBoolean(boolean v) throws IOException {
+        out.writeBoolean(v);
+    }
+
+    @Override
+    public void writeByte(int v) throws IOException {
+        out.writeByte(v);
+    }
+
+    @Override
+    public void writeShort(int v) throws IOException {
+        out.writeByte(v & 0xFF);
+        out.writeByte((v >> 8) & 0xFF);
+    }
+
+    @Override
+    public void writeChar(int v) throws IOException {
+        out.writeByte(v & 0xFF);
+        out.writeByte((v >> 8) & 0xFF);
+    }
+
+    @Override
+    public void writeInt(int v) throws IOException {
+        out.writeByte(v & 0xFF);
+        out.writeByte((v >> 8) & 0xFF);
+        out.writeByte((v >> 16) & 0xFF);
+        out.writeByte((v >> 24) & 0xFF);
+    }
+
+    @Override
+    public void writeLong(long v) throws IOException {
+        out.writeByte((int) (v & 0xFF));
+        out.writeByte((int) ((v >> 8) & 0xFF));
+        out.writeByte((int) ((v >> 16) & 0xFF));
+        out.writeByte((int) ((v >> 24) & 0xFF));
+        out.writeByte((int) ((v >> 32) & 0xFF));
+        out.writeByte((int) ((v >> 40) & 0xFF));
+        out.writeByte((int) ((v >> 48) & 0xFF));
+        out.writeByte((int) ((v >> 56) & 0xFF));
+    }
+
+    @Override
+    public void writeFloat(float v) throws IOException {
+        int intBits = Float.floatToIntBits(v);
+        writeInt(intBits);
+    }
+
+    @Override
+    public void writeDouble(double v) throws IOException {
+        long longBits = Double.doubleToLongBits(v);
+        writeLong(longBits);
+    }
+
+    @Override
+    public void writeBytes(String s) throws IOException {
+        out.writeBytes(s);
+    }
+
+    @Override
+    public void writeChars(String s) throws IOException {
+        for (int i = 0; i < s.length(); i++) {
+            writeChar(s.charAt(i));
+        }
+    }
+
+    @Override
+    public void writeUTF(String s) throws IOException {
+        out.writeUTF(s);
+    }
+}
+
+

--- a/jvector-base/src/main/java/com/github/jbellis/jvector/disk/OnDiskGraphIndex.java
+++ b/jvector-base/src/main/java/com/github/jbellis/jvector/disk/OnDiskGraphIndex.java
@@ -166,6 +166,7 @@ public class OnDiskGraphIndex<T> implements GraphIndex<T>, AutoCloseable, Accoun
     // to OnHeapGraphIndex just for this method.  Maybe that will end up the best solution,
     // but I'm not sure yet.
     public static <T> void write(GraphIndex<T> graph, RandomAccessVectorValues<T> vectors, DataOutput out) throws IOException {
+        out = new LittleEndianDataOutput(out);
         assert graph.size() == vectors.size() : String.format("graph size %d != vectors size %d", graph.size(), vectors.size());
 
         var view = graph.getView();

--- a/jvector-base/src/main/java/com/github/jbellis/jvector/disk/RandomAccessReader.java
+++ b/jvector-base/src/main/java/com/github/jbellis/jvector/disk/RandomAccessReader.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 /**
  * This is a subset of DataInput, plus seek and readFully(float[]), which allows implementations
  * to use a more efficient option like FloatBuffer.
+ * <p>
+ * ALL DATA IS EXPECTED TO BE WRITTEN AND READ IN LITTLE-ENDIAN ORDER.
  */
 public interface RandomAccessReader extends AutoCloseable {
     public void seek(long offset) throws IOException;

--- a/jvector-base/src/main/java/com/github/jbellis/jvector/example/util/MMapReader.java
+++ b/jvector-base/src/main/java/com/github/jbellis/jvector/example/util/MMapReader.java
@@ -46,7 +46,7 @@ public class MMapReader implements RandomAccessReader {
             scratch = new byte[bytesToRead];
         }
         readFully(scratch);
-        ByteBuffer byteBuffer = ByteBuffer.wrap(scratch).order(ByteOrder.BIG_ENDIAN);
+        ByteBuffer byteBuffer = ByteBuffer.wrap(scratch).order(ByteOrder.LITTLE_ENDIAN);
         byteBuffer.asFloatBuffer().get(floats);
     }
 

--- a/jvector-base/src/main/java/com/github/jbellis/jvector/example/util/MMapReaderSupplier.java
+++ b/jvector-base/src/main/java/com/github/jbellis/jvector/example/util/MMapReaderSupplier.java
@@ -13,7 +13,7 @@ public class MMapReaderSupplier implements ReaderSupplier {
     private final MMapBuffer buffer;
 
     public MMapReaderSupplier(Path path) throws IOException {
-        buffer = new MMapBuffer(path, FileChannel.MapMode.READ_ONLY, ByteOrder.BIG_ENDIAN);
+        buffer = new MMapBuffer(path, FileChannel.MapMode.READ_ONLY, ByteOrder.LITTLE_ENDIAN);
     }
 
     @Override

--- a/jvector-base/src/main/java/com/github/jbellis/jvector/example/util/SimpleMappedReader.java
+++ b/jvector-base/src/main/java/com/github/jbellis/jvector/example/util/SimpleMappedReader.java
@@ -22,6 +22,7 @@ import sun.misc.Unsafe;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.lang.reflect.Field;
+import java.nio.ByteOrder;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
@@ -59,6 +60,7 @@ public class SimpleMappedReader implements RandomAccessReader {
             throw new RuntimeException("MappedRandomAccessReader doesn't support large files");
         }
         mbb = raf.getChannel().map(FileChannel.MapMode.READ_ONLY, 0, raf.length());
+        mbb.order(ByteOrder.LITTLE_ENDIAN);
         mbb.load();
         raf.close();
     }

--- a/jvector-base/src/main/java/com/github/jbellis/jvector/example/util/SimpleMappedReader.java
+++ b/jvector-base/src/main/java/com/github/jbellis/jvector/example/util/SimpleMappedReader.java
@@ -66,7 +66,8 @@ public class SimpleMappedReader implements RandomAccessReader {
     }
 
     private SimpleMappedReader(MappedByteBuffer sourceMbb) {
-        mbb = sourceMbb;
+        mbb = (MappedByteBuffer) sourceMbb.duplicate();
+        mbb.order(ByteOrder.LITTLE_ENDIAN);
     }
 
     @Override
@@ -104,6 +105,6 @@ public class SimpleMappedReader implements RandomAccessReader {
     }
 
     public SimpleMappedReader duplicate() {
-        return new SimpleMappedReader((MappedByteBuffer) mbb.duplicate());
+        return new SimpleMappedReader(mbb);
     }
 }

--- a/jvector-base/src/main/java/com/github/jbellis/jvector/pq/ProductQuantization.java
+++ b/jvector-base/src/main/java/com/github/jbellis/jvector/pq/ProductQuantization.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.github.jbellis.jvector.disk.Io;
+import com.github.jbellis.jvector.disk.LittleEndianDataOutput;
 import com.github.jbellis.jvector.disk.RandomAccessReader;
 import com.github.jbellis.jvector.vector.VectorUtil;
 
@@ -241,6 +242,7 @@ public class ProductQuantization {
 
     public void write(DataOutput out) throws IOException
     {
+        out = new LittleEndianDataOutput(out);
         if (globalCentroid == null) {
             out.writeInt(0);
         } else {


### PR DESCRIPTION
Before patch (queryRuns=2)
```
hdf5/nytimes-256-angular.hdf5: 289761 base and 9991 query vectors loaded, dimensions 256
PQ@128 build 18.09s,
PQ encode 1.93s,
Build M=8 ef=128 in 15.05s with 0.92 short edges
  Query PQ=true top 100/2 recall 0.7115 in 3.55s after 43910864 nodes visited
  Query PQ=true top 100/4 recall 0.7621 in 6.26s after 79406058 nodes visited
Build M=16 ef=128 in 29.56s with 0.80 short edges
  Query PQ=true top 100/2 recall 0.7853 in 5.68s after 79359556 nodes visited
  Query PQ=true top 100/4 recall 0.8369 in 10.99s after 149524964 nodes visited
Build M=32 ef=128 in 67.65s with 0.59 short edges
  Query PQ=true top 100/2 recall 0.8444 in 10.02s after 140328630 nodes visited
  Query PQ=true top 100/4 recall 0.8969 in 19.18s after 269563424 nodes visited
```

After patch:
```
hdf5/nytimes-256-angular.hdf5: 289761 base and 9991 query vectors loaded, dimensions 256
PQ@128 build 22.73s,
PQ encode 2.15s,
Build M=8 ef=128 in 15.60s with 0.92 short edges
  Query PQ=true top 100/2 recall 0.7113 in 3.34s after 44005096 nodes visited
  Query PQ=true top 100/4 recall 0.7625 in 6.41s after 79669490 nodes visited
Build M=16 ef=128 in 29.95s with 0.80 short edges
  Query PQ=true top 100/2 recall 0.7856 in 5.55s after 79299732 nodes visited
  Query PQ=true top 100/4 recall 0.8368 in 11.04s after 148996964 nodes visited
Build M=32 ef=128 in 66.47s with 0.59 short edges
  Query PQ=true top 100/2 recall 0.8442 in 9.58s after 139674146 nodes visited
  Query PQ=true top 100/4 recall 0.8967 in 19.29s after 268166768 nodes visited
```

Doesn't seem to make a difference really