### PR TITLE
Add simd approach for summing the cached PQ products of each encoded vector

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/CompressedDecoder.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/CompressedDecoder.java
@@ -44,7 +44,7 @@ abstract class CompressedDecoder implements NeighborSimilarity.ApproximateScoreF
         }
 
         protected float decodedSimilarity(byte[] encoded) {
-            return VectorUtil.zipAndSum(partialSums, ProductQuantization.CLUSTERS, encoded);
+            return VectorUtil.assembleAndSum(partialSums, ProductQuantization.CLUSTERS, encoded);
         }
     }
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/ProductQuantization.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/ProductQuantization.java
@@ -19,6 +19,7 @@ package io.github.jbellis.jvector.pq;
 import io.github.jbellis.jvector.disk.Io;
 import io.github.jbellis.jvector.disk.RandomAccessReader;
 import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
+import io.github.jbellis.jvector.util.RamUsageEstimator;
 import io.github.jbellis.jvector.vector.VectorUtil;
 
 import java.io.DataOutput;
@@ -100,8 +101,8 @@ public class ProductQuantization {
     /**
      * Encodes the given vectors in parallel using the PQ codebooks.
      */
-    public List<byte[]> encodeAll(List<float[]> vectors) {
-        return vectors.stream().parallel().map(this::encode).collect(Collectors.toList());
+    public byte[][] encodeAll(List<float[]> vectors) {
+        return vectors.stream().parallel().map(this::encode).toArray(byte[][]::new);
     }
 
     /**
@@ -343,5 +344,14 @@ public class ProductQuantization {
 
     public float[] getCenter() {
         return globalCentroid;
+    }
+
+    public long memorySize() {
+        long size = 0;
+        for (int i = 0; i < codebooks.length; i++)
+            for (int j = 0; j < codebooks[i].length; j++)
+                size += RamUsageEstimator.sizeOf(codebooks[i][j]);
+
+        return size;
     }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/DefaultVectorUtilSupport.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/DefaultVectorUtilSupport.java
@@ -247,4 +247,14 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
     }
     return result;
   }
+
+  @Override
+  public float assembleAndSum(float[] data, int dataBase, byte[] baseOffsets)
+  {
+      float sum = 0f;
+      for (int i = 0; i < baseOffsets.length; i++) {
+          sum += data[dataBase * i + Byte.toUnsignedInt(baseOffsets[i])];
+      }
+      return sum;
+  }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/DefaultVectorizationProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/DefaultVectorizationProvider.java
@@ -25,11 +25,11 @@
 package io.github.jbellis.jvector.vector;
 
 /** Default provider returning scalar implementations. */
-final class DefaultVectorizationProvider extends VectorizationProvider {
+final public class DefaultVectorizationProvider extends VectorizationProvider {
 
   private final VectorUtilSupport vectorUtilSupport;
 
-  DefaultVectorizationProvider() {
+  public DefaultVectorizationProvider() {
     vectorUtilSupport = new DefaultVectorUtilSupport();
   }
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtil.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtil.java
@@ -229,7 +229,7 @@ public final class VectorUtil {
   public static float[] sub(float[] lhs, float[] rhs) {
     return impl.sub(lhs, rhs);
   }
-  public static float zipAndSum(float[] data, int dataBase, byte[] dataOffsets) {
+  public static float assembleAndSum(float[] data, int dataBase, byte[] dataOffsets) {
     return impl.assembleAndSum(data, dataBase, dataOffsets);
   }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtil.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtil.java
@@ -229,4 +229,7 @@ public final class VectorUtil {
   public static float[] sub(float[] lhs, float[] rhs) {
     return impl.sub(lhs, rhs);
   }
+  public static float zipAndSum(float[] data, int dataBase, byte[] dataOffsets) {
+    return impl.assembleAndSum(data, dataBase, dataOffsets);
+  }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtilSupport.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtilSupport.java
@@ -69,4 +69,19 @@ public interface VectorUtilSupport {
 
   /** @return lhs - rhs, element-wise */
   public float[] sub(float[] lhs, float[] rhs);
+
+  /**
+   * Calculates the sum of sparse points in a vector.
+   *
+   * This assumes the data vector is a 2d matrix which has been flattened into 1 dimension
+   * so rather than data[n][m] it's data[n * m].  With this layout this method can quickly
+   * assemble the data from this heap and sum it.
+   *
+   * @param data the vector of all datapoints
+   * @param baseIndex the start of the data in the offset table
+   *                  (scaled by the index of the lookup table)
+   * @param baseOffsets bytes that represent offsets from the baseIndex
+   * @return the sum of the points
+   */
+  public float assembleAndSum(float[] data, int baseIndex, byte[] baseOffsets);
 }

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Bench.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Bench.java
@@ -188,9 +188,8 @@ public class Bench {
 
         start = System.nanoTime();
         var quantizedVectors = pq.encodeAll(ds.baseVectors);
-        System.out.format("PQ encode %.2fs,%n", (System.nanoTime() - start) / 1_000_000_000.0);
-
         var compressedVectors = new CompressedVectors(pq, quantizedVectors);
+        System.out.format("PQ encoded %d[%.2f MB] in %.2fs,%n", ds.baseVectors.size(), (compressedVectors.memorySize()/1024f/1024f) , (System.nanoTime() - start) / 1_000_000_000.0);
 
         var testDirectory = Files.createTempDirectory("BenchGraphDir");
 

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/microbench/SimilarityBench.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/microbench/SimilarityBench.java
@@ -18,7 +18,7 @@ package io.github.jbellis.jvector.microbench;
 
 
 import io.github.jbellis.jvector.vector.DefaultVectorizationProvider;
-import io.github.jbellis.jvector.vector.PanamaVectorizationProvider;
+import io.github.jbellis.jvector.vector.VectorUtil;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 @Fork(warmups = 1, value = 1, jvmArgsAppend = {"--add-modules=jdk.incubator.vector"})
 public class SimilarityBench {
 
-    private static final PanamaVectorizationProvider simd = new PanamaVectorizationProvider();
     private static final DefaultVectorizationProvider java = new DefaultVectorizationProvider();
 
     static int SIZE = 1536;
@@ -67,7 +66,7 @@ public class SimilarityBench {
     @Threads(8)
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     public void zipAndSumSimd(Blackhole bh, Parameters p) {
-        bh.consume(simd.getVectorUtilSupport().assembleAndSum(q1, 0, indexes));
+        bh.consume(VectorUtil.assembleAndSum(q1, 0, indexes));
     }
 
     @Benchmark

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/vector/TestVectorizationProvider.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/vector/TestVectorizationProvider.java
@@ -58,4 +58,30 @@ public class TestVectorizationProvider extends RandomizedTest {
             Assert.assertEquals(a.getVectorUtilSupport().squareDistance(v1, v2), b.getVectorUtilSupport().squareDistance(v1, v2));
         }
     }
+
+    @Test
+    public void testAssembleAndSum() {
+        Assume.assumeTrue(hasSimd);
+
+        VectorizationProvider a = new DefaultVectorizationProvider();
+        VectorizationProvider b = VectorizationProvider.getInstance();
+
+        for (int i = 0; i < 1000; i++) {
+            float[] v2 = GraphIndexTestCase.randomVector(getRandom(), 256);
+
+            float[] v3 = new float[32];
+            byte[] offsets = new byte[32];
+            int skipSize = 256/32;
+            //Assemble v3 from bits of v2
+            for (int j = 0, c = 0; j < 256; j+=skipSize, c++) {
+                v3[c] = v2[j];
+                offsets[c] = (byte) (c * skipSize);
+            }
+
+            Assert.assertEquals(a.getVectorUtilSupport().sum(v3), b.getVectorUtilSupport().sum(v3), 0.0001);
+            Assert.assertEquals(a.getVectorUtilSupport().sum(v3), a.getVectorUtilSupport().assembleAndSum(v2, 0, offsets), 0.0001);
+            Assert.assertEquals(b.getVectorUtilSupport().sum(v3), b.getVectorUtilSupport().assembleAndSum(v2, 0, offsets), 0.0001);
+
+        }
+    }
 }

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorUtilSupport.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorUtilSupport.java
@@ -19,9 +19,7 @@ package io.github.jbellis.jvector.vector;
 import java.util.List;
 
 final class
-PanamaVectorUtilSupport implements VectorUtilSupport
-{
-
+PanamaVectorUtilSupport implements VectorUtilSupport {
     @Override
     public float dotProduct(float[] a, float[] b) {
         return SimdOps.dotProduct(a, b);
@@ -85,5 +83,10 @@ PanamaVectorUtilSupport implements VectorUtilSupport
     @Override
     public float[] sub(float[] lhs, float[] rhs) {
         return SimdOps.sub(lhs, rhs);
+    }
+
+    @Override
+    public float assembleAndSum(float[] data, int baseIndex, byte[] baseOffsets) {
+        return SimdOps.assembleAndSum(data, baseIndex, baseOffsets);
     }
 }

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorizationProvider.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorizationProvider.java
@@ -18,6 +18,10 @@ package io.github.jbellis.jvector.vector;
 
 public class PanamaVectorizationProvider extends VectorizationProvider
 {
+    static {
+        System.setProperty("jdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK", "0");
+    }
+
     private final VectorUtilSupport vectorUtilSupport;
 
     public PanamaVectorizationProvider() {

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
@@ -554,7 +554,7 @@ final class SimdOps {
     static float assembleAndSum512(float[] data, int dataBase, byte[] baseOffsets) {
         int[] convOffsets = scratchInt512.get();
         FloatVector sum = FloatVector.zero(FloatVector.SPECIES_512);
-        for (int i = 0, c = 0; i < baseOffsets.length; i += ByteVector.SPECIES_128.length(), c++) {
+        for (int i = 0; i < baseOffsets.length; i += ByteVector.SPECIES_128.length()) {
             var scale = IntVector.zero(IntVector.SPECIES_512).addIndex(1).add(i).mul(dataBase);
 
             ByteVector.fromArray(ByteVector.SPECIES_128, baseOffsets, i)
@@ -573,7 +573,7 @@ final class SimdOps {
     static float assembleAndSum256(float[] data, int dataBase, byte[] baseOffsets) {
         int[] convOffsets = scratchInt256.get();
         FloatVector sum = FloatVector.zero(FloatVector.SPECIES_256);
-        for (int i = 0, c = 0; i < baseOffsets.length; i += ByteVector.SPECIES_64.length(), c++) {
+        for (int i = 0; i < baseOffsets.length; i += ByteVector.SPECIES_64.length()) {
             var scale = IntVector.zero(IntVector.SPECIES_256).addIndex(1).add(i).mul(dataBase);
 
             ByteVector.fromArray(ByteVector.SPECIES_64, baseOffsets, i)

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
@@ -24,9 +24,14 @@ import jdk.incubator.vector.VectorOperators;
 import java.util.List;
 
 final class SimdOps {
-    static {
-        System.setProperty("jdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK", "0");
-    }
+
+    static final boolean HAS_AVX512 = IntVector.SPECIES_PREFERRED == IntVector.SPECIES_512;
+    static final IntVector BYTE_TO_INT_MASK_512 = IntVector.broadcast(IntVector.SPECIES_512, 0xff);
+    static final IntVector BYTE_TO_INT_MASK_256 = IntVector.broadcast(IntVector.SPECIES_256, 0xff);
+
+    static final ThreadLocal<int[]> scratchInt512 = ThreadLocal.withInitial(() -> new int[IntVector.SPECIES_512.length()]);
+    static final ThreadLocal<int[]> scratchInt256 = ThreadLocal.withInitial(() -> new int[IntVector.SPECIES_256.length()]);
+
 
     static float sum(float[] vector) {
         var sum = FloatVector.zero(FloatVector.SPECIES_PREFERRED);
@@ -540,4 +545,48 @@ final class SimdOps {
 
         return result;
     }
+
+    static float assembleAndSum(float[] data, int dataBase, byte[] baseOffsets) {
+        return HAS_AVX512 ? assembleAndSum512(data, dataBase, baseOffsets)
+               : assembleAndSum256(data, dataBase, baseOffsets);
+    }
+
+    static float assembleAndSum512(float[] data, int dataBase, byte[] baseOffsets) {
+        int[] convOffsets = scratchInt512.get();
+        FloatVector sum = FloatVector.zero(FloatVector.SPECIES_512);
+        for (int i = 0, c = 0; i < baseOffsets.length; i += ByteVector.SPECIES_128.length(), c++) {
+            var scale = IntVector.zero(IntVector.SPECIES_512).addIndex(1).add(i).mul(dataBase);
+
+            ByteVector.fromArray(ByteVector.SPECIES_128, baseOffsets, i)
+                    .convertShape(VectorOperators.B2I, IntVector.SPECIES_512, 0)
+                    .lanewise(VectorOperators.AND, BYTE_TO_INT_MASK_512)
+                    .reinterpretAsInts()
+                    .add(scale)
+                    .intoArray(convOffsets,0);
+
+            sum = sum.add(FloatVector.fromArray(FloatVector.SPECIES_512, data, 0, convOffsets, 0));
+        }
+
+        return sum.reduceLanes(VectorOperators.ADD);
+    }
+
+    static float assembleAndSum256(float[] data, int dataBase, byte[] baseOffsets) {
+        int[] convOffsets = scratchInt256.get();
+        FloatVector sum = FloatVector.zero(FloatVector.SPECIES_256);
+        for (int i = 0, c = 0; i < baseOffsets.length; i += ByteVector.SPECIES_64.length(), c++) {
+            var scale = IntVector.zero(IntVector.SPECIES_256).addIndex(1).add(i).mul(dataBase);
+
+            ByteVector.fromArray(ByteVector.SPECIES_64, baseOffsets, i)
+                    .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0)
+                    .lanewise(VectorOperators.AND, BYTE_TO_INT_MASK_256)
+                    .reinterpretAsInts()
+                    .add(scale)
+                    .intoArray(convOffsets,0);
+
+            sum = sum.add(FloatVector.fromArray(FloatVector.SPECIES_256, data, 0, convOffsets, 0));
+        }
+
+        return sum.reduceLanes(VectorOperators.ADD);
+    }
+
 }


### PR DESCRIPTION
With this change the PQ goes from ~40% slower to ~20%

WITHOUT:
```
Wikipedia: 100000 base and 10000 query vectors loaded, dimensions 1536
PQ@384 build 43.81s,
PQ encode 3.28s,
Build M=8 ef=60 in 9.89s with 0.59 short edges
  Query PQ=false top 101/1 recall 0.8925 in 18.69s after 18255466 nodes visited
  Query PQ=true top 101/1 recall 0.8058 in 4.08s after 18507140 nodes visited
  Query PQ=false top 101/2 recall 0.9439 in 4.38s after 31216274 nodes visited
  Query PQ=true top 101/2 recall 0.9346 in 5.76s after 31572008 nodes visited
Build M=8 ef=80 in 11.92s with 0.63 short edges
  Query PQ=false top 101/1 recall 0.8962 in 2.43s after 19259294 nodes visited
  Query PQ=true top 101/1 recall 0.8074 in 3.69s after 19553584 nodes visited
  Query PQ=false top 101/2 recall 0.9461 in 4.57s after 32799340 nodes visited
  Query PQ=true top 101/2 recall 0.9396 in 5.61s after 33243558 nodes visited
```

WITH:
```
Wikipedia: 100000 base and 10000 query vectors loaded, dimensions 1536
PQ@384 build 43.44s,
PQ encoded 100000[41.15 MB] in 3.15s,
Build M=8 ef=60 in 30.18s with 0.59 short edges
  Query PQ=false top 101/1 recall 0.8894 in 2.78s after 18943356 nodes visited
  Query PQ=true top 101/1 recall 0.8062 in 3.47s after 19154798 nodes visited
  Query PQ=false top 101/2 recall 0.9432 in 4.29s after 31844642 nodes visited
  Query PQ=true top 101/2 recall 0.9363 in 4.54s after 32244298 nodes visited
Build M=8 ef=80 in 12.77s with 0.63 short edges
  Query PQ=false top 101/1 recall 0.8953 in 2.54s after 19224834 nodes visited
  Query PQ=true top 101/1 recall 0.8094 in 3.14s after 19530716 nodes visited
  Query PQ=false top 101/2 recall 0.9471 in 4.73s after 32693720 nodes visited
  Query PQ=true top 101/2 recall 0.9399 in 4.99s after 33086598 nodes visited

```