### PR TITLE
Switch to Jctools NBHML and FieldUpdater

### DIFF
--- a/jvector-base/pom.xml
+++ b/jvector-base/pom.xml
@@ -11,4 +11,12 @@
     </parent>
     <artifactId>jvector-base</artifactId>
     <name>Base</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jctools</groupId>
+            <artifactId>jctools-core</artifactId>
+            <version>4.0.1</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Bench.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Bench.java
@@ -137,7 +137,7 @@ public class Bench {
         var mGrid = List.of(8, 12, 16, 24, 32, 48, 64);
         var efConstructionGrid = List.of(60, 80, 100, 120, 160, 200, 400, 600, 800);
         var efSearchGrid = List.of(1, 2);
-        var diskGrid = List.of(false, true);
+        var diskGrid = List.of( true);
 
         // this dataset contains more than 10k query vectors, so we limit it with .subList
         var adaSet = loadWikipediaData();


### PR DESCRIPTION
EXISTING:
```
PQ@384 build 27.32s,
PQ encoded 100000 vectors [41.15 MB] in 3.26s,
Build M=8 ef=60 in 73.49s with 0.60 short edges
  Query PQ=true top 101/1 recall 0.7980 in 4.16s after 19444540 nodes visited
  Query PQ=true top 101/2 recall 0.9303 in 5.40s after 32572630 nodes visited
Build M=8 ef=80 in 13.96s with 0.63 short edges
  Query PQ=true top 101/1 recall 0.8074 in 3.50s after 20492178 nodes visited
  Query PQ=true top 101/2 recall 0.9362 in 5.20s after 34097234 nodes visited
Build M=8 ef=100 in 15.27s with 0.66 short edges
  Query PQ=true top 101/1 recall 0.8090 in 3.62s after 20328850 nodes visited
  Query PQ=true top 101/2 recall 0.9410 in 5.41s after 34196102 nodes visited
```

WITH NBHM:
```
PQ@384 build 27.03s,
PQ encoded 100000 vectors [41.15 MB] in 3.14s,
Build M=8 ef=60 in 12.80s with 0.59 short edges
  Query PQ=true top 101/1 recall 0.8038 in 3.94s after 18803416 nodes visited
  Query PQ=true top 101/2 recall 0.9323 in 4.97s after 31918654 nodes visited
Build M=8 ef=80 in 16.09s with 0.63 short edges
  Query PQ=true top 101/1 recall 0.8085 in 3.42s after 19716632 nodes visited
  Query PQ=true top 101/2 recall 0.9388 in 5.56s after 33320638 nodes visited
Build M=8 ef=100 in 18.57s with 0.66 short edges
  Query PQ=true top 101/1 recall 0.8117 in 3.45s after 20690602 nodes visited
  Query PQ=true top 101/2 recall 0.9416 in 5.29s after 34765870 nodes visited
```

WITH MBHML:
```
PQ@384 build 26.53s,
PQ encoded 100000 vectors [41.15 MB] in 3.14s,
Build M=8 ef=60 in 16.43s with 0.60 short edges
  Query PQ=true top 101/1 recall 0.8053 in 3.97s after 18712402 nodes visited
  Query PQ=true top 101/2 recall 0.9355 in 5.24s after 31836994 nodes visited
Build M=8 ef=80 in 12.77s with 0.63 short edges
  Query PQ=true top 101/1 recall 0.8082 in 3.41s after 19770528 nodes visited
  Query PQ=true top 101/2 recall 0.9402 in 5.11s after 33250648 nodes visited
Build M=8 ef=100 in 14.83s with 0.66 short edges
  Query PQ=true top 101/1 recall 0.8103 in 3.36s after 20285888 nodes visited
  Query PQ=true top 101/2 recall 0.9419 in 5.24s after 34188580 nodes visited
```