### PR TITLE
Adds DenseIntMap for building graph with much less contention. back to zero dependency!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JVector
 <a href="https://trendshift.io/repositories/2946" target="_blank"><img src="https://trendshift.io/api/badge/repositories/2946" alt="jbellis%2Fjvector | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
-JVector is a pure Java embedded vector search engine, used by [DataStax Astra DB](https://www.datastax.com/products/datastax-astra) and (soon) Apache Cassandra.
+JVector is a pure Java, zero dependency, embedded vector search engine, used by [DataStax Astra DB](https://www.datastax.com/products/datastax-astra) and (soon) Apache Cassandra.
 
 What is JVector?
 - Algorithmic-fast. JVector uses state of the art graph algorithms inspired by DiskANN and related research that offer high recall and low latency.

--- a/jvector-base/pom.xml
+++ b/jvector-base/pom.xml
@@ -11,12 +11,4 @@
     </parent>
     <artifactId>jvector-base</artifactId>
     <name>Base</name>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.jctools</groupId>
-            <artifactId>jctools-core</artifactId>
-            <version>4.0.1</version>
-        </dependency>
-    </dependencies>
 </project>

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/DenseIntMap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/DenseIntMap.java
@@ -1,0 +1,76 @@
+package io.github.jbellis.jvector.util;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.concurrent.locks.StampedLock;
+
+/**
+ * A Map of int -> T where the int keys are dense and start at zero, but the
+ * size of the map is not known in advance.  This provides fast, concurrent
+ * updates and minimizes contention when the map is resized.
+ */
+public class DenseIntMap<T> {
+    private volatile AtomicReferenceArray<T> objects;
+    private final AtomicInteger size;
+    private final StampedLock sl = new StampedLock();
+
+    public DenseIntMap(int initialSize) {
+        objects = new AtomicReferenceArray<>(initialSize);
+        size = new AtomicInteger();
+    }
+
+    /**
+     * @param key ordinal
+     */
+    public void put(int key, T value) {
+        ensureCapacity(key);
+        long stamp;
+        do {
+            stamp = sl.tryOptimisticRead();
+            objects.set(key, value);
+        } while (!sl.validate(stamp));
+
+        size.incrementAndGet();
+    }
+
+    /**
+     * @return number of items that have been added
+     */
+    public int size() {
+        return size.get();
+    }
+
+    /**
+     * @param key ordinal
+     * @return the value of the key, or null if not set
+     */
+    public T get(int key) {
+        // since objects is volatile, we don't need to lock
+        var ref = objects;
+        if (key >= ref.length()) {
+            return null;
+        }
+        return ref.get(key);
+    }
+
+    private void ensureCapacity(int node) {
+        if (node < objects.length()) {
+            return;
+        }
+
+        long stamp = sl.writeLock();
+        try {
+            var oldArray = objects;
+            if (node >= oldArray.length()) {
+                int newSize = ArrayUtil.oversize(node + 1, RamUsageEstimator.NUM_BYTES_OBJECT_REF);
+                var newArray = new AtomicReferenceArray<T>(newSize);
+                for (int i = 0; i < oldArray.length(); i++) {
+                    newArray.set(i, oldArray.get(i));
+                }
+                objects = newArray;
+            }
+        } finally {
+            sl.unlockWrite(stamp);
+        }
+    }
+}

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/PhysicalCoreExecutor.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/PhysicalCoreExecutor.java
@@ -35,4 +35,8 @@ public class PhysicalCoreExecutor {
     public <T> T submit(Supplier<T> run) {
         return pool.submit(run::get).join();
     }
+
+    public static int getPhysicalCoreCount() {
+        return physicalCoreCount;
+    }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/PoolingSupport.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/PoolingSupport.java
@@ -1,10 +1,9 @@
 package io.github.jbellis.jvector.util;
 
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
-
-import org.jctools.queues.MpmcArrayQueue;
 
 /**
  * Allows any object to be pooled and released when work is done.
@@ -95,7 +94,7 @@ public abstract class PoolingSupport<T> {
     {
         private final int limit;
         private final AtomicInteger created;
-        private final MpmcArrayQueue<T> queue;
+        private final LinkedBlockingQueue<T> queue;
         private final Supplier<T> initialValue;
 
         private ThreadPooling(Supplier<T> initialValue) {
@@ -106,7 +105,7 @@ public abstract class PoolingSupport<T> {
         private ThreadPooling(int threadLimit, Supplier<T> initialValue) {
             this.limit = threadLimit;
             this.created = new AtomicInteger(0);
-            this.queue = new MpmcArrayQueue<>(threadLimit);
+            this.queue = new LinkedBlockingQueue<>(threadLimit);
             this.initialValue = initialValue;
         }
 

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/microbench/GraphBuildBench.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/microbench/GraphBuildBench.java
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
 import io.github.jbellis.jvector.example.util.DataSet;
+import io.github.jbellis.jvector.example.util.Hdf5Loader;
 import io.github.jbellis.jvector.example.util.SiftLoader;
 import io.github.jbellis.jvector.graph.GraphIndexBuilder;
 import io.github.jbellis.jvector.graph.ListRandomAccessVectorValues;
@@ -26,23 +27,8 @@ import org.openjdk.jmh.infra.Blackhole;
 
 @Warmup(iterations = 1, time = 5)
 @Measurement(iterations = 1, time = 10)
-@Fork(warmups = 0, value = 1, jvmArgsAppend = {"--add-modules=jdk.incubator.vector"})//"-XX:+UnlockDiagnosticVMOptions", "--enable-preview", "-XX:+PreserveFramePointer", "-XX:+DebugNonSafepoints", "-XX:+AlwaysPreTouch", "-Xmx14G", "-Xms14G"})
+@Fork(warmups = 0, value = 1, jvmArgsAppend = {"--add-modules=jdk.incubator.vector", "-XX:+UnlockDiagnosticVMOptions", "--enable-preview", "-XX:+PreserveFramePointer", "-XX:+DebugNonSafepoints"})
 public class GraphBuildBench {
-
-    private static DataSet loadWikipediaData() throws IOException
-    {
-        var baseVectors = SiftLoader.readFvecs("fvec/pages_ada_002_100k_base_vectors.fvec");
-        var queryVectors = SiftLoader.readFvecs("fvec/pages_ada_002_100k_query_vectors_10k.fvec").subList(0, 10_000);
-        var gt = SiftLoader.readIvecs("fvec/pages_ada_002_100k_indices_query_vectors_10k.ivec").subList(0, 10_000);
-        var ds = new DataSet("wikipedia",
-                VectorSimilarityFunction.DOT_PRODUCT,
-                baseVectors,
-                queryVectors,
-                gt);
-        System.out.format("%nWikipedia: %d base and %d query vectors loaded, dimensions %d%n",
-                baseVectors.size(), queryVectors.size(), baseVectors.get(0).length);
-        return ds;
-    }
 
     @State(Scope.Benchmark)
     public static class Parameters {
@@ -50,13 +36,8 @@ public class GraphBuildBench {
         final ListRandomAccessVectorValues ravv;
 
         public Parameters() {
-            try {
-                this.ds = loadWikipediaData();
-                this.ravv = new ListRandomAccessVectorValues(ds.baseVectors, ds.baseVectors.get(0).length);
-            }
-            catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+            this.ds = Hdf5Loader.load("hdf5/glove-100-angular.hdf5");
+            this.ravv = new ListRandomAccessVectorValues(ds.baseVectors, ds.baseVectors.get(0).length);
         }
     }
 
@@ -64,23 +45,12 @@ public class GraphBuildBench {
     @BenchmarkMode(Mode.Throughput)
     @OutputTimeUnit(TimeUnit.SECONDS)
     public void testGraphBuild(Blackhole bh, Parameters p) {
-
-        int pqDims = p.ravv.dimension() / 4;
         long start = System.nanoTime();
-        var pq = ProductQuantization.compute(p.ravv, pqDims, p.ds.similarityFunction == VectorSimilarityFunction.EUCLIDEAN);
-        System.out.format("PQ@%s build %.2fs,%n", pqDims, (System.nanoTime() - start) / 1_000_000_000.0);
-
-        start = System.nanoTime();
-        var quantizedVectors = pq.encodeAll(p.ds.baseVectors);
-        var compressedVectors = new CompressedVectors(pq, quantizedVectors);
-        System.out.format("PQ encoded %d vectors [%.2f MB] in %.2fs,%n", p.ds.baseVectors.size(), (compressedVectors.memorySize()/1024f/1024f) , (System.nanoTime() - start) / 1_000_000_000.0);
-
-        start = System.nanoTime();
-        GraphIndexBuilder<float[]> graphIndexBuilder =  new GraphIndexBuilder<>(p.ravv, VectorEncoding.FLOAT32, p.ds.similarityFunction, 8, 40, 1.2f, 1.4f);
+        GraphIndexBuilder<float[]> graphIndexBuilder =  new GraphIndexBuilder<>(p.ravv, VectorEncoding.FLOAT32, p.ds.similarityFunction, 8, 60, 1.2f, 1.4f);
         var onHeapGraph = graphIndexBuilder.build();
         var avgShortEdges = IntStream.range(0, onHeapGraph.size()).mapToDouble(i -> onHeapGraph.getNeighbors(i).getShortEdges()).average().orElseThrow();
         System.out.format("Build M=%d ef=%d in %.2fs with %.2f short edges%n",
-                8, 60, (System.nanoTime() - start) / 1_000_000_000.0, avgShortEdges);
+                32, 600, (System.nanoTime() - start) / 1_000_000_000.0, avgShortEdges);
     }
 }
 

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
@@ -141,7 +141,7 @@ final class SimdOps {
         for (; i < vectorizedLength; i += FloatVector.SPECIES_64.length()) {
             FloatVector a = FloatVector.fromArray(FloatVector.SPECIES_64, v1, v1offset + i);
             FloatVector b = FloatVector.fromArray(FloatVector.SPECIES_64, v2, v2offset + i);
-            sum = sum.add(a.mul(b));
+            sum = a.fma(b, sum);
         }
 
         float res = sum.reduceLanes(VectorOperators.ADD);
@@ -166,7 +166,7 @@ final class SimdOps {
         for (; i < vectorizedLength; i += FloatVector.SPECIES_128.length()) {
             FloatVector a = FloatVector.fromArray(FloatVector.SPECIES_128, v1, v1offset + i);
             FloatVector b = FloatVector.fromArray(FloatVector.SPECIES_128, v2, v2offset + i);
-            sum = sum.add(a.mul(b));
+            sum = a.fma(b, sum);
         }
 
         float res = sum.reduceLanes(VectorOperators.ADD);
@@ -192,7 +192,7 @@ final class SimdOps {
         for (; i < vectorizedLength; i += FloatVector.SPECIES_256.length()) {
             FloatVector a = FloatVector.fromArray(FloatVector.SPECIES_256, v1, v1offset + i);
             FloatVector b = FloatVector.fromArray(FloatVector.SPECIES_256, v2, v2offset + i);
-            sum = sum.add(a.mul(b));
+            sum = a.fma(b, sum);
         }
 
         float res = sum.reduceLanes(VectorOperators.ADD);
@@ -217,7 +217,7 @@ final class SimdOps {
         for (; i < vectorizedLength; i += FloatVector.SPECIES_PREFERRED.length()) {
             FloatVector a = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, v1, v1offset + i);
             FloatVector b = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, v2, v2offset + i);
-            sum = sum.add(a.mul(b));
+            sum = a.fma(b, sum);
         }
 
         float res = sum.reduceLanes(VectorOperators.ADD);
@@ -267,7 +267,7 @@ final class SimdOps {
         for (int i = 0; i < vectorizedLength; i += FloatVector.SPECIES_PREFERRED.length()) {
             var a = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, v1, i);
             var b = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, v2, i);
-            vsum = vsum.add(a.mul(b));
+            vsum = a.fma(b, vsum);
             vaMagnitude = vaMagnitude.add(a.mul(a));
             vbMagnitude = vbMagnitude.add(b.mul(b));
         }


### PR DESCRIPTION
Very large improvement in build times by moving from a CHM to a dense array for index graph.

This PR also removes jctools and switched to fma for vector code.
 
Glove 100 build times
Before:
```
Build M=32 ef=600 in 2117.60s with 0.79 short edges
```

After:
```
Build M=32 ef=600 in 1577.92s with 0.79 short edges
```