### PR TITLE
Fix usage of null acceptOrds in SiftSmall example

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphSearcher.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphSearcher.java
@@ -115,7 +115,7 @@ public class GraphSearcher<T> {
      * @param topK          the number of results to look for
      * @param threshold     the minimum similarity (0..1) to accept; 0 will accept everything. (Experimental!)
      * @param acceptOrds    a Bits instance indicating which nodes are acceptable results.
-     *                      If null, all nodes are acceptable.
+     *                      If {@link Bits#ALL}, all nodes are acceptable.
      *                      It is caller's responsibility to ensure that there are enough acceptable nodes
      *                      that we don't search the entire graph trying to satisfy topK.
      * @return a SearchResult containing the topK results and the number of nodes visited during the search.
@@ -135,7 +135,7 @@ public class GraphSearcher<T> {
      *                      comparisons of the vectors for re-ranking at the end of the search.
      * @param topK          the number of results to look for
      * @param acceptOrds    a Bits instance indicating which nodes are acceptable results.
-     *                      If null, all nodes are acceptable.
+     *                      If {@link Bits#ALL}, all nodes are acceptable.
      *                      It is caller's responsibility to ensure that there are enough acceptable nodes
      *                      that we don't search the entire graph trying to satisfy topK.
      * @return a SearchResult containing the topK results and the number of nodes visited during the search.

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
@@ -24,6 +24,7 @@ import io.github.jbellis.jvector.graph.*;
 import io.github.jbellis.jvector.pq.CompressedVectors;
 import io.github.jbellis.jvector.pq.PQVectors;
 import io.github.jbellis.jvector.pq.ProductQuantization;
+import io.github.jbellis.jvector.util.Bits;
 import io.github.jbellis.jvector.vector.VectorEncoding;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 
@@ -86,12 +87,12 @@ public class SiftSmall {
             var searcher = new GraphSearcher.Builder<>(view).build();
             if (compressedVectors == null) {
                 NodeSimilarity.ExactScoreFunction sf = (j) -> VectorSimilarityFunction.EUCLIDEAN.compare(queryVector, ravv.vectorValue(j));
-                nn = searcher.search(sf, null, 100, null).getNodes();
+                nn = searcher.search(sf, null, 100, Bits.ALL).getNodes();
             }
             else {
                 NodeSimilarity.ApproximateScoreFunction sf = compressedVectors.approximateScoreFunctionFor(queryVector, VectorSimilarityFunction.EUCLIDEAN);
                 NodeSimilarity.ReRanker<float[]> rr = (j, vectors) -> VectorSimilarityFunction.EUCLIDEAN.compare(queryVector, vectors.get(j));
-                nn = searcher.search(sf, rr, 100, null).getNodes();
+                nn = searcher.search(sf, rr, 100, Bits.ALL).getNodes();
             }
 
             var gt = groundTruth.get(i);


### PR DESCRIPTION
Since #117, `acceptOrds` should not be `null`. Instead, `Bits.ALL` should be used.
Also updated `GraphSearcher#search` javadoc to match implementation.