### PR TITLE
Fixed some thread pool usage bugs; CachingGraphIndex's cacheDistance can be customized

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/CachingGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/CachingGraphIndex.java
@@ -33,9 +33,14 @@ public class CachingGraphIndex implements GraphIndex<float[]>, AutoCloseable, Ac
 
     public CachingGraphIndex(OnDiskGraphIndex<float[]> graph)
     {
+        this(graph, CACHE_DISTANCE);
+    }
+
+    public CachingGraphIndex(OnDiskGraphIndex<float[]> graph, int cacheDistance)
+    {
         this.graph = graph;
         try {
-            this.cache = GraphCache.load(graph, CACHE_DISTANCE);
+            this.cache = GraphCache.load(graph, cacheDistance);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
@@ -163,12 +163,12 @@ public class GraphIndexBuilder<T> {
         removeDeletedNodes();
 
         // clean up overflowed neighbor lists
-        IntStream.range(0, graph.getIdUpperBound()).parallel().forEach(i -> {
+        PhysicalCoreExecutor.instance.execute(() -> IntStream.range(0, graph.getIdUpperBound()).parallel().forEach(i -> {
             var neighbors = graph.getNeighbors(i);
             if (neighbors != null) {
                 neighbors.cleanup();
             }
-        });
+        }));
 
         // reconnect any orphaned nodes.  this will maintain neighbors size
         reconnectOrphanedNodes();
@@ -187,9 +187,9 @@ public class GraphIndexBuilder<T> {
             var connectedNodes = new AtomicFixedBitSet(graph.getIdUpperBound());
             connectedNodes.set(graph.entry());
             var entryNeighbors = graph.getNeighbors(graph.entry()).getCurrent();
-            IntStream.range(0, entryNeighbors.size).parallel().forEach(node -> {
+            PhysicalCoreExecutor.instance.execute(() -> IntStream.range(0, entryNeighbors.size).parallel().forEach(node -> {
                 findConnected(connectedNodes, entryNeighbors.node[node]);
-            });
+            }));
 
             // reconnect unreachable nodes
             var nReconnected = new AtomicInteger();

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/PhysicalCoreExecutor.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/PhysicalCoreExecutor.java
@@ -15,6 +15,7 @@
  */
 package io.github.jbellis.jvector.util;
 
+import java.io.Closeable;
 import java.util.concurrent.ForkJoinPool;
 import java.util.function.Supplier;
 
@@ -31,7 +32,7 @@ import io.github.jbellis.jvector.pq.ProductQuantization;
  *
  * Knowing how many physical cores a machine has is left to the operator (however the default of 1/2 cores is today often correct).
  */
-public class PhysicalCoreExecutor {
+public class PhysicalCoreExecutor implements Closeable {
     private static final int physicalCoreCount = Integer.getInteger("jvector.physical_core_count", Math.max(1, Runtime.getRuntime().availableProcessors()/2));
 
     public static final PhysicalCoreExecutor instance = new PhysicalCoreExecutor(physicalCoreCount);
@@ -53,5 +54,10 @@ public class PhysicalCoreExecutor {
 
     public static int getPhysicalCoreCount() {
         return physicalCoreCount;
+    }
+    
+    @Override
+    public void close() {
+        pool.shutdownNow();
     }
 }

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Bench.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Bench.java
@@ -36,6 +36,7 @@ import io.github.jbellis.jvector.pq.CompressedVectors;
 import io.github.jbellis.jvector.pq.ProductQuantization;
 import io.github.jbellis.jvector.pq.VectorCompressor;
 import io.github.jbellis.jvector.util.Bits;
+import io.github.jbellis.jvector.util.PhysicalCoreExecutor;
 import io.github.jbellis.jvector.vector.VectorEncoding;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 
@@ -160,7 +161,7 @@ public class Bench {
         LongAdder topKfound = new LongAdder();
         LongAdder nodesVisited = new LongAdder();
         for (int k = 0; k < queryRuns; k++) {
-            IntStream.range(0, ds.queryVectors.size()).parallel().forEach(i -> {
+            PhysicalCoreExecutor.instance.execute(() -> IntStream.range(0, ds.queryVectors.size()).parallel().forEach(i -> {
                 var queryVector = ds.queryVectors.get(i);
                 SearchResult sr;
                 if (cv != null) {
@@ -178,7 +179,7 @@ public class Bench {
                 var n = topKCorrect(topK, sr.getNodes(), gt);
                 topKfound.add(n);
                 nodesVisited.add(sr.getVisitedCount());
-            });
+            }));
         }
         return new ResultSummary((int) topKfound.sum(), nodesVisited.sum()); // TODO do we care enough about visited count to hack it back into searcher?
     }

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/DataSetCreator.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/DataSetCreator.java
@@ -16,6 +16,7 @@
 
 package io.github.jbellis.jvector.example.util;
 
+import io.github.jbellis.jvector.util.PhysicalCoreExecutor;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 
 import java.util.AbstractMap;
@@ -50,23 +51,23 @@ public class DataSetCreator {
         }
 
         // Create query vectors and compute ground truth
-        var queries = IntStream.range(0, nQueries).parallel().mapToObj(i -> {
+        var queries = PhysicalCoreExecutor.instance.submit(() -> IntStream.range(0, nQueries).parallel().mapToObj(i -> {
             var R = ThreadLocalRandom.current();
-            float[] q = new float[] {gridWidth * R.nextFloat(), gridWidth * R.nextFloat()};
+            float[] q = new float[]{gridWidth * R.nextFloat(), gridWidth * R.nextFloat()};
 
             // Compute the ground truth within a bounding box around the query point
             Set<Integer> gt = IntStream.range(0, baseVectors.size())
-                .filter(j -> {
-                    float[] v = baseVectors.get(j);
-                    return v[0] >= q[0] - topK && v[0] <= q[0] + topK && v[1] >= q[1] - topK && v[1] <= q[1] + topK;
-                })
-                .boxed() // allows sorting with custom comparator
-                .sorted(Comparator.comparingDouble((Integer j) -> VectorSimilarityFunction.EUCLIDEAN.compare(q, baseVectors.get(j))).reversed())
-                .limit(topK)
-                .collect(Collectors.toSet());
+                    .filter(j -> {
+                        float[] v = baseVectors.get(j);
+                        return v[0] >= q[0] - topK && v[0] <= q[0] + topK && v[1] >= q[1] - topK && v[1] <= q[1] + topK;
+                    })
+                    .boxed() // allows sorting with custom comparator
+                    .sorted(Comparator.comparingDouble((Integer j) -> VectorSimilarityFunction.EUCLIDEAN.compare(q, baseVectors.get(j))).reversed())
+                    .limit(topK)
+                    .collect(Collectors.toSet());
 
             return new AbstractMap.SimpleEntry<>(q, gt);
-        }).collect(Collectors.toConcurrentMap(Map.Entry::getKey, Map.Entry::getValue)).entrySet();
+        }).collect(Collectors.toConcurrentMap(Map.Entry::getKey, Map.Entry::getValue)).entrySet());
         var queryVectors = queries.stream().map(Map.Entry::getKey).collect(Collectors.toList());
         var groundTruth = queries.stream().map(Map.Entry::getValue).collect(Collectors.toList());
 

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/Deep1BLoader.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/Deep1BLoader.java
@@ -16,6 +16,8 @@
 
 package io.github.jbellis.jvector.example.util;
 
+import io.github.jbellis.jvector.util.PhysicalCoreExecutor;
+
 import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -40,7 +42,7 @@ public class Deep1BLoader {
         int perThread = count / threadCount;
         int remainder = count % threadCount;
 
-        IntStream.range(0, threadCount).parallel().forEach(threadNum -> {
+        PhysicalCoreExecutor.instance.execute(() -> IntStream.range(0, threadCount).parallel().forEach(threadNum -> {
             try (var raf = new RandomAccessFile(filePath, "r")) {
                 long startPosition = 8L + ((long) threadNum * perThread + Math.min(threadNum, remainder)) * dimension * Float.BYTES;
                 raf.seek(startPosition);
@@ -56,11 +58,10 @@ public class Deep1BLoader {
                     floatBuffer.get(vector);
                     vectors[threadNum * perThread + (Math.min(threadNum, remainder)) + j] = vector;
                 }
-            }
-            catch (IOException e) {
+            } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
-        });
+        }));
 
         System.out.println("Completed reading " + filePath);
         return List.of(vectors);

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/Hdf5Loader.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/Hdf5Loader.java
@@ -16,6 +16,7 @@
 
 package io.github.jbellis.jvector.example.util;
 
+import io.github.jbellis.jvector.util.PhysicalCoreExecutor;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.jhdf.HdfFile;
 import io.jhdf.api.Dataset;
@@ -52,13 +53,13 @@ public class Hdf5Loader {
             if (((FloatingPoint) queryDataset.getDataType()).getBitPrecision() == 64) {
                 // lastfm dataset contains f64 queries but f32 everything else
                 var doubles = ((double[][]) queryDataset.getData());
-                queryVectors = IntStream.range(0, doubles.length).parallel().mapToObj(i -> {
+                queryVectors = PhysicalCoreExecutor.instance.submit(() -> IntStream.range(0, doubles.length).parallel().mapToObj(i -> {
                     var a = new float[doubles[i].length];
                     for (int j = 0; j < doubles[i].length; j++) {
                         a[j] = (float) doubles[i][j];
                     }
                     return a;
-                }).toArray(float[][]::new);
+                }).toArray(float[][]::new));
             } else {
                 queryVectors = (float[][]) queryDataset.getData();
             }


### PR DESCRIPTION
The changes mainly include the following parts:
- Fixed some forkJoin thread pool usage bugs, Otherwise the CPU may rush to 100%
- PhysicalCoreExecutor can exit gracefully
- CachingGraphIndex's cacheDistance can be customized