### PR TITLE
Add optional FJP args for indexing and quantization

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/VectorCompressor.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/VectorCompressor.java
@@ -16,16 +16,24 @@
 
 package io.github.jbellis.jvector.pq;
 
+import io.github.jbellis.jvector.util.PhysicalCoreExecutor;
+
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.ForkJoinPool;
 
 /**
  * Interface for vector compression.  T is the encoded (compressed) vector type;
  * it will be an array type.
  */
 public interface VectorCompressor<T> {
-    T[] encodeAll(List<float[]> vectors);
+
+    default T[] encodeAll(List<float[]> vectors) {
+        return encodeAll(vectors, PhysicalCoreExecutor.pool());
+    }
+
+    T[] encodeAll(List<float[]> vectors, ForkJoinPool simdExecutor);
 
     T encode(float[] v);
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/PhysicalCoreExecutor.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/PhysicalCoreExecutor.java
@@ -36,6 +36,10 @@ public class PhysicalCoreExecutor {
 
     public static final PhysicalCoreExecutor instance = new PhysicalCoreExecutor(physicalCoreCount);
 
+    public static ForkJoinPool pool() {
+        return instance.pool;
+    }
+    
     private final ForkJoinPool pool;
 
     private PhysicalCoreExecutor(int cores) {


### PR DESCRIPTION
By default, SIMD operations are using `PhysicalCoreExecutor` and non-SIMD operations are using `FJP.commonPool()`.

With this addition, one can define custom fork-join pools for these tasks in `GraphIndexBuilder`, `ProductQuantization` and `BinaryQuantization`.