### PR TITLE
Call threadLocal.remove() for ThreadPooling#onClosed

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/PoolingSupport.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/PoolingSupport.java
@@ -135,7 +135,7 @@ public abstract class PoolingSupport<T> {
 
         @Override
         protected void onClosed(Pooled<T> value) {
-
+            threadLocal.remove();
         }
     }
 


### PR DESCRIPTION
There is an apparent leak in the `ThreadPooling` class. We pass a reference to the `ThreadPooling` class into the `ThreadLocal`'s value, which creates a strong reference to the class, which in turn creates a strong reference to the `threadLocal` object and therefore prevents the class from being garbage collected.

Assuming my understanding of references is correct (which is not a given), we just need to call `threadLocal.remove()`.