### PR TITLE
Parallelize GraphIndexBuilder.removeDeletedNodes()

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
@@ -465,9 +465,7 @@ public class GraphIndexBuilder<T> {
         }
 
         // repair affected nodes
-        for (var node : affectedLiveNodes) {
-            addNNDescentConnections(node);
-        }
+        simdExecutor.submit(() -> affectedLiveNodes.stream().parallel().forEach(this::addNNDescentConnections)).join();
 
         // reset deleted collection
         deletedNodes.clear();


### PR DESCRIPTION
`GraphIndexBuilder.addNNDescentConnections()` was being called serially for each effected node during cleanup after some nodes are marked as deleted.

When there are too many (like hundreds of thousands), `GraphIndexBuilder.cleanup()` was taking too much time, and most of it was in `removeDeletedNodes()` while calling `addNNDescentConnections()` in loop.

With this change `addNNDescentConnections()` is called in parallel using SIMD FJP.