### PR TITLE
Remove caching of vectors encountered during search, update reranker interface accordingly

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeSimilarity.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeSimilarity.java
@@ -61,7 +61,7 @@ public interface NodeSimilarity {
         float similarityTo(int node2);
     }
 
-    interface ReRanker<T> {
-        float similarityTo(int node2, Map<Integer, T> vectors);
+    interface ReRanker {
+        float similarityTo(int node2);
     }
 }

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Bench.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Bench.java
@@ -166,7 +166,7 @@ public class Bench {
                 if (cv != null) {
                     var view = index.getView();
                     NodeSimilarity.ApproximateScoreFunction sf = cv.approximateScoreFunctionFor(queryVector, ds.similarityFunction);
-                    NodeSimilarity.ReRanker<float[]> rr = (j, vectors) -> ds.similarityFunction.compare(queryVector, vectors.get(j));
+                    NodeSimilarity.ReRanker rr = (j) -> ds.similarityFunction.compare(queryVector, exactVv.vectorValue(j));
                     sr = new GraphSearcher.Builder<>(view)
                             .build()
                             .search(sf, rr, efSearch, Bits.ALL);

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/IPCService.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/IPCService.java
@@ -267,7 +267,7 @@ public class IPCService
             SearchResult r;
             if (ctx.cv != null) {
                 NodeSimilarity.ApproximateScoreFunction sf = ctx.cv.approximateScoreFunctionFor(queryVector, ctx.similarityFunction);
-                NodeSimilarity.ReRanker<float[]> rr = (j, vectors) -> ctx.similarityFunction.compare(queryVector, vectors.get(j));
+                NodeSimilarity.ReRanker rr = (j) -> ctx.similarityFunction.compare(queryVector, ctx.ravv.vectorValue(j));
                 r = new GraphSearcher.Builder<>(ctx.index.getView()).build().search(sf, rr, searchEf, Bits.ALL);
             } else {
                 r = GraphSearcher.search(queryVector, topK, ctx.ravv, VectorEncoding.FLOAT32, ctx.similarityFunction, ctx.index, Bits.ALL);

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
@@ -94,7 +94,7 @@ public class SiftSmall {
             }
             else {
                 NodeSimilarity.ApproximateScoreFunction sf = compressedVectors.approximateScoreFunctionFor(queryVector, VectorSimilarityFunction.EUCLIDEAN);
-                NodeSimilarity.ReRanker<float[]> rr = (j, vectors) -> VectorSimilarityFunction.EUCLIDEAN.compare(queryVector, vectors.get(j));
+                NodeSimilarity.ReRanker rr = (j) -> VectorSimilarityFunction.EUCLIDEAN.compare(queryVector, ravv.vectorValue(j));
                 nn = searcher.search(sf, rr, 100, Bits.ALL).getNodes();
             }
 

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/Test2DThreshold.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/Test2DThreshold.java
@@ -74,7 +74,7 @@ public class Test2DThreshold extends LuceneTestCase {
             for (int i = 0; i < 10; i++) {
                 TestParams tp = createTestParams(vectors);
                 searcher = new GraphSearcher.Builder<>(onDiskGraph.getView()).build();
-                NodeSimilarity.ReRanker<float[]> reranker = (j, map) -> VectorSimilarityFunction.EUCLIDEAN.compare(tp.q, map.get(j));
+                NodeSimilarity.ReRanker reranker = (j) -> VectorSimilarityFunction.EUCLIDEAN.compare(tp.q, ravv.vectorValue(j));
                 var asf = cv.approximateScoreFunctionFor(tp.q, VectorSimilarityFunction.EUCLIDEAN);
                 var result = searcher.search(asf, reranker, vectors.length, tp.th, Bits.ALL);
 


### PR DESCRIPTION
Removing the overhead of reading all visited nodes' vectors and deserializing saves over 20% of query time pretty consistently.  The smaller topK is, the larger the win we expect (since the ratio of visited nodes to returned is higher).  These are the topK=100 results.

Before:
```
intfloat_e5-small-v2_100000: 100000 base and 10000 query vectors created, dimensions 384
Build M=16 ef=100 in 5.91s with avg degree 32.00 and 0.67 short edges
Uncompressed vectors
  Query (memory) top 100/1 recall 0.8770 in 0.80s after 38,348,960 nodes visited
  Query (disk) top 100/1 recall 0.8770 in 1.66s after 38,348,960 nodes visited
  Query (memory) top 100/2 recall 0.9369 in 1.41s after 68,255,682 nodes visited
  Query (disk) top 100/2 recall 0.9369 in 2.81s after 68,255,682 nodes visited
ProductQuantization(96) build in 4.11s,
ProductQuantization(96) encoded 100,000 vectors [11.43 MB] in 0.49s
  Query top 100/1 recall 0.6870 in 1.17s after 40,240,018 nodes visited
  Query top 100/2 recall 0.8692 in 1.25s after 71,757,458 nodes visited

intfloat_e5-base-v2_100000: 100000 base and 10000 query vectors created, dimensions 768
Build M=16 ef=100 in 10.21s with avg degree 32.00 and 0.63 short edges
Uncompressed vectors
  Query (memory) top 100/1 recall 0.9136 in 1.59s after 35,488,740 nodes visited
  Query (disk) top 100/1 recall 0.9136 in 3.18s after 35,488,740 nodes visited
  Query (memory) top 100/2 recall 0.9581 in 3.03s after 62,305,568 nodes visited
  Query (disk) top 100/2 recall 0.9581 in 6.09s after 62,305,568 nodes visited
ProductQuantization(192) build in 7.71s,
ProductQuantization(192) encoded 100,000 vectors [21.34 MB] in 0.96s
  Query top 100/1 recall 0.7814 in 1.23s after 36,038,946 nodes visited
  Query top 100/2 recall 0.9382 in 1.99s after 63,249,316 nodes visited

intfloat_e5-large-v2_100000: 100000 base and 10000 query vectors created, dimensions 1024
Build M=16 ef=100 in 13.81s with avg degree 32.00 and 0.61 short edges
Uncompressed vectors
  Query (memory) top 100/1 recall 0.9213 in 1.88s after 33,193,238 nodes visited
  Query (disk) top 100/1 recall 0.9213 in 3.85s after 33,193,238 nodes visited
  Query (memory) top 100/2 recall 0.9601 in 3.58s after 58,361,454 nodes visited
  Query (disk) top 100/2 recall 0.9601 in 7.30s after 58,361,454 nodes visited
ProductQuantization(256) build in 9.96s,
ProductQuantization(256) encoded 100,000 vectors [27.94 MB] in 1.31s
  Query top 100/1 recall 0.8105 in 1.52s after 33,421,056 nodes visited
  Query top 100/2 recall 0.9473 in 2.48s after 59,039,350 nodes visited

textembedding-gecko_100000: 99750 base and 9250 query vectors created, dimensions 768
Build M=16 ef=100 in 9.32s with avg degree 32.00 and 0.56 short edges
Uncompressed vectors
  Query (memory) top 100/1 recall 0.9101 in 1.59s after 34,695,948 nodes visited
  Query (disk) top 100/1 recall 0.9101 in 3.17s after 34,695,948 nodes visited
  Query (memory) top 100/2 recall 0.9610 in 2.96s after 61,252,004 nodes visited
  Query (disk) top 100/2 recall 0.9610 in 5.81s after 61,252,004 nodes visited
ProductQuantization(192) build in 7.43s,
ProductQuantization(192) encoded 99,750 vectors [21.29 MB] in 0.93s
  Query top 100/1 recall 0.8039 in 1.17s after 35,384,870 nodes visited
  Query top 100/2 recall 0.9509 in 1.92s after 62,507,564 nodes visited

ada_002_100000: 99920 base and 9760 query vectors created, dimensions 1536
Build M=16 ef=100 in 15.93s with avg degree 31.99 and 0.46 short edges
Uncompressed vectors
  Query (memory) top 100/1 recall 0.9555 in 2.50s after 28,916,608 nodes visited
  Query (disk) top 100/1 recall 0.9555 in 4.99s after 28,916,608 nodes visited
  Query (memory) top 100/2 recall 0.9826 in 4.54s after 49,730,186 nodes visited
  Query (disk) top 100/2 recall 0.9826 in 9.06s after 49,730,186 nodes visited
ProductQuantization(384) build in 15.08s,
ProductQuantization(384) encoded 99,920 vectors [41.12 MB] in 1.96s
  Query top 100/1 recall 0.8435 in 2.12s after 29,612,744 nodes visited
  Query top 100/2 recall 0.9768 in 3.38s after 50,801,212 nodes visited
```

After:
```
intfloat_e5-small-v2_100000: 100000 base and 10000 query vectors created, dimensions 384
Build M=16 ef=100 in 6.06s with avg degree 32.00 and 0.67 short edges
Uncompressed vectors
  Query (memory) top 100/1 recall 0.8761 in 0.85s after 38,442,668 nodes visited
  Query (disk) top 100/1 recall 0.8761 in 1.66s after 38,442,668 nodes visited
  Query (memory) top 100/2 recall 0.9368 in 1.35s after 68,546,926 nodes visited
  Query (disk) top 100/2 recall 0.9368 in 2.70s after 68,546,926 nodes visited
ProductQuantization(96) build in 3.68s,
ProductQuantization(96) encoded 100,000 vectors [11.43 MB] in 0.48s
  Query top 100/1 recall 0.6884 in 0.91s after 40,025,342 nodes visited
  Query top 100/2 recall 0.8704 in 0.90s after 71,649,660 nodes visited

intfloat_e5-base-v2_100000: 100000 base and 10000 query vectors created, dimensions 768
Build M=16 ef=100 in 9.81s with avg degree 32.00 and 0.63 short edges
Uncompressed vectors
  Query (memory) top 100/1 recall 0.9133 in 1.59s after 35,664,102 nodes visited
  Query (disk) top 100/1 recall 0.9133 in 3.16s after 35,664,102 nodes visited
  Query (memory) top 100/2 recall 0.9564 in 2.98s after 62,472,218 nodes visited
  Query (disk) top 100/2 recall 0.9564 in 5.85s after 62,472,218 nodes visited
ProductQuantization(192) build in 7.49s,
ProductQuantization(192) encoded 100,000 vectors [21.34 MB] in 0.91s
  Query top 100/1 recall 0.7847 in 1.05s after 36,374,662 nodes visited
  Query top 100/2 recall 0.9392 in 1.66s after 63,899,724 nodes visited

intfloat_e5-large-v2_100000: 100000 base and 10000 query vectors created, dimensions 1024
Build M=16 ef=100 in 13.42s with avg degree 32.00 and 0.61 short edges
Uncompressed vectors
  Query (memory) top 100/1 recall 0.9199 in 1.88s after 33,252,962 nodes visited
  Query (disk) top 100/1 recall 0.9199 in 3.74s after 33,252,962 nodes visited
  Query (memory) top 100/2 recall 0.9598 in 3.59s after 58,482,258 nodes visited
  Query (disk) top 100/2 recall 0.9598 in 7.16s after 58,482,258 nodes visited
ProductQuantization(256) build in 10.11s,
ProductQuantization(256) encoded 100,000 vectors [27.94 MB] in 1.26s
  Query top 100/1 recall 0.7930 in 1.31s after 32,577,426 nodes visited
  Query top 100/2 recall 0.9436 in 2.02s after 57,994,518 nodes visited

textembedding-gecko_100000: 99750 base and 9250 query vectors created, dimensions 768
Build M=16 ef=100 in 9.38s with avg degree 32.00 and 0.56 short edges
Uncompressed vectors
  Query (memory) top 100/1 recall 0.9095 in 1.56s after 34,343,156 nodes visited
^[OP  Query (disk) top 100/1 recall 0.9095 in 3.14s after 34,343,156 nodes visited
  Query (memory) top 100/2 recall 0.9603 in 2.88s after 60,715,286 nodes visited
  Query (disk) top 100/2 recall 0.9603 in 5.76s after 60,715,286 nodes visited
ProductQuantization(192) build in 7.51s,
ProductQuantization(192) encoded 99,750 vectors [21.29 MB] in 0.92s
  Query top 100/1 recall 0.8030 in 1.08s after 35,093,224 nodes visited
  Query top 100/2 recall 0.9504 in 1.61s after 62,050,560 nodes visited

ada_002_100000: 99920 base and 9760 query vectors created, dimensions 1536
Build M=16 ef=100 in 15.79s with avg degree 31.99 and 0.46 short edges
Uncompressed vectors
  Query (memory) top 100/1 recall 0.9554 in 2.45s after 28,466,700 nodes visited
  Query (disk) top 100/1 recall 0.9554 in 4.95s after 28,466,700 nodes visited
  Query (memory) top 100/2 recall 0.9825 in 4.50s after 49,236,138 nodes visited
  Query (disk) top 100/2 recall 0.9825 in 9.06s after 49,236,138 nodes visited
ProductQuantization(384) build in 15.13s,
ProductQuantization(384) encoded 99,920 vectors [41.12 MB] in 1.91s
  Query top 100/1 recall 0.8456 in 1.79s after 28,903,454 nodes visited
  Query top 100/2 recall 0.9768 in 2.59s after 50,064,392 nodes visited
```