### PR TITLE
Make GraphIndexBuilder.markNodeDeleted thread-safe

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
@@ -30,6 +30,7 @@ import io.github.jbellis.jvector.util.Bits;
 import io.github.jbellis.jvector.util.DenseIntMap;
 import io.github.jbellis.jvector.util.GrowableBitSet;
 import io.github.jbellis.jvector.util.RamUsageEstimator;
+import io.github.jbellis.jvector.util.SynchronizedGrowableBitSet;
 
 import java.io.DataOutput;
 import java.io.IOException;
@@ -50,7 +51,7 @@ public class OnHeapGraphIndex<T> implements GraphIndex<T>, Accountable {
     private final AtomicInteger entryPoint = new AtomicInteger(-1);
 
     private final DenseIntMap<ConcurrentNeighborSet> nodes;
-    private final BitSet deletedNodes = new GrowableBitSet(0);
+    private final BitSet deletedNodes = new SynchronizedGrowableBitSet(0);
     private final AtomicInteger maxNodeId = new AtomicInteger(-1);
 
     // max neighbors/edges per node

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/GrowableBitSet.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/GrowableBitSet.java
@@ -21,6 +21,8 @@ package io.github.jbellis.jvector.util;
  * does so, it will grow its internal storage multiplicatively, assuming that more growth will be
  * needed in the future. This is the important difference from FixedBitSet + FBS.ensureCapacity,
  * which grows the minimum necessary each time.
+ * <p>
+ * For thread-safe version see {@link SynchronizedGrowableBitSet}.
  */
 public class GrowableBitSet extends BitSet {
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/SynchronizedGrowableBitSet.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/SynchronizedGrowableBitSet.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.util;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * A thread-safe {@link BitSet} implementation that grows as needed to accommodate set(index) calls. When it
+ * does so, it will grow its internal storage multiplicatively, assuming that more growth will be
+ * needed in the future. This is the important difference from FixedBitSet + FBS.ensureCapacity,
+ * which grows the minimum necessary each time.
+ *
+ * @see GrowableBitSet
+ */
+public class SynchronizedGrowableBitSet extends BitSet {
+
+  private final java.util.BitSet bitSet;
+  private final Lock lock = new ReentrantLock();
+
+  public SynchronizedGrowableBitSet(java.util.BitSet bitSet) {
+    this.bitSet = bitSet;
+  }
+
+  public SynchronizedGrowableBitSet(int initialBits) {
+    this.bitSet = new java.util.BitSet(initialBits);
+  }
+
+  @Override
+  public void clear(int index) {
+    lock.lock();
+    try {
+      bitSet.clear(index);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public void clear() {
+    lock.lock();
+    try {
+      bitSet.clear();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public boolean get(int index) {
+    lock.lock();
+    try {
+      return bitSet.get(index);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public boolean getAndSet(int index) {
+    lock.lock();
+    try {
+      boolean v = get(index);
+      set(index);
+      return v;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public int length() {
+    lock.lock();
+    try {
+      return bitSet.length();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public void set(int i) {
+    lock.lock();
+    try {
+      bitSet.set(i);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public void clear(int startIndex, int endIndex) {
+    lock.lock();
+    try {
+      if (startIndex == 0 && endIndex == bitSet.length()) {
+        bitSet.clear();
+        return;
+      } else if (startIndex >= endIndex) {
+        return;
+      }
+      bitSet.clear(startIndex, endIndex);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public int cardinality() {
+    lock.lock();
+    try {
+      return bitSet.cardinality();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public int approximateCardinality() {
+    lock.lock();
+    try {
+      return bitSet.cardinality();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public int prevSetBit(int index) {
+    lock.lock();
+    try {
+      return bitSet.previousSetBit(index);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public int nextSetBit(int i) {
+    lock.lock();
+    try {
+      int next = bitSet.nextSetBit(i);
+      if (next == -1) {
+        next = DocIdSetIterator.NO_MORE_DOCS;
+      }
+      return next;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/util/TestSynchronizedGrowableBitSet.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/util/TestSynchronizedGrowableBitSet.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.util;
+
+public class TestSynchronizedGrowableBitSet extends BaseBitSetTestCase<SynchronizedGrowableBitSet> {
+
+  @Override
+  public SynchronizedGrowableBitSet copyOf(BitSet bs, int length) {
+    final SynchronizedGrowableBitSet set = new SynchronizedGrowableBitSet(length);
+    for (int doc = bs.nextSetBit(0);
+        doc != DocIdSetIterator.NO_MORE_DOCS;
+        doc = doc + 1 >= length ? DocIdSetIterator.NO_MORE_DOCS : bs.nextSetBit(doc + 1)) {
+      set.set(doc);
+    }
+    return set;
+  }
+}
+


### PR DESCRIPTION
`GraphIndexBuilder.markNodeDeleted` uses `GrowableBitSet` as the backing storage to track deleted nodes. But since `GrowableBitSet` itself is not thread-safe, `markNodeDeleted` is not thread-safe either.

Added a synchronized version of `GrowableBitSet` and used it as the storage for deleted nodes.

_Currently `SynchronizedGrowableBitSet` uses a single lock to guard all access to `BitSet`. If more concurrency needed while deleting nodes, a lock-free & atomic version can be introduced._

Closes #174