### PR TITLE
Don't create new ScoreTracker.NoOpTracker each time

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphSearcher.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphSearcher.java
@@ -171,7 +171,7 @@ public class GraphSearcher<T> {
         }
 
         prepareScratchState(view.size());
-        var scoreTracker = threshold > 0 ? new ScoreTracker.NormalDistributionTracker(threshold) : new ScoreTracker.NoOpTracker();
+        var scoreTracker = threshold > 0 ? new ScoreTracker.NormalDistributionTracker(threshold) : ScoreTracker.NO_OP;
         if (ep < 0) {
             return new SearchResult(new SearchResult.NodeScore[0], visited, 0);
         }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ScoreTracker.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ScoreTracker.java
@@ -21,6 +21,9 @@ import org.apache.commons.math3.distribution.NormalDistribution;
 import org.apache.commons.math3.stat.StatUtils;
 
 interface ScoreTracker {
+
+    ScoreTracker NO_OP = new NoOpTracker();
+
     void track(float score);
 
     boolean shouldStop(int numVisited);


### PR DESCRIPTION
just a nit, reducing number of objects created during search.