### PR TITLE
Handle the case of removing all nodes in the cleanup

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
@@ -199,6 +199,12 @@ public class GraphIndexBuilder<T> {
         // backlinks can cause neighbors to soft-overflow, so do this before neighbors cleanup
         removeDeletedNodes();
 
+        if (graph.size() == 0) {
+            // After removing all the deleted nodes, we might end up with an empty graph.
+            // The calls below expect a valid entry node, but we do not have one right now.
+            return;
+        }
+
         // clean up overflowed neighbor lists
         parallelExecutor.submit(() -> IntStream.range(0, graph.getIdUpperBound()).parallel().forEach(i -> {
             var neighbors = graph.getNeighbors(i);

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestDeletions.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestDeletions.java
@@ -114,4 +114,20 @@ public class TestDeletions extends LuceneTestCase {
         var reloadedGraph = b2.getGraph();
         assertGraphEquals(graph, reloadedGraph);
     }
+
+    @Test
+    public void testCleanupAfterMarkingAllNodesAsDeleted() {
+        int dimension = 2;
+        var ravv = MockVectorValues.fromValues(createRandomFloatVectors(10, dimension, getRandom()));
+        var builder = new GraphIndexBuilder<>(ravv, VectorEncoding.FLOAT32, VectorSimilarityFunction.COSINE, 2, 10, 1.0f, 1.0f);
+        var graph = TestUtil.buildSequentially(builder, ravv);
+
+        for (var i = 0; i < graph.size(); i++) {
+            graph.markDeleted(i);
+        }
+
+        builder.cleanup();
+
+        assertEquals(0, graph.size());
+    }
 }


### PR DESCRIPTION
We might mark all nodes of the graph as deleted before calling cleanup.

Doing so causes graph's entry node to become unset(-1) after the `removeDeletedNodes` call in the `cleanup` method.

The rest of the cleanup logic expects a valid entry node for the graph to function correctly. Therefore, I added an early return to handle such a case.