### PR TITLE
Improve GraphIndexBuilder#cleanup doc for concurrent searches

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
@@ -187,7 +187,8 @@ public class GraphIndexBuilder<T> {
      * <p>
      * Must be called before writing to disk.
      * <p>
-     * May be called multiple times, but should not be called during concurrent modifications to the graph.
+     * May be called multiple times, but should not be called during concurrent modifications to the graph
+     * or while executing concurrent searches on the graph.
      */
     public void cleanup() {
         if (graph.size() == 0) {


### PR DESCRIPTION
Added that `GraphIndexBuilder#cleanup` should not be called concurrently with searches on graph.

Closes #188