### PR TITLE
pq supports off-heap memory to reduce GC and improve performance

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/UnsafeUtils.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/UnsafeUtils.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jbellis.jvector.util;
+
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.util.Locale;
+
+public class UnsafeUtils {
+
+    private static final Unsafe UNSAFE = getUnsafe();
+    private static final Field ADDRESS_FIELD = getBufferAddressField();
+    private static final long UNSAFE_COPY_THRESHOLD = 1024L * 1024L * 4;
+    private static final long BYTE_ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
+
+
+    private static Unsafe getUnsafe() {
+        try {
+            Field f = Unsafe.class.getDeclaredField("theUnsafe");
+            f.setAccessible(true);
+            return (Unsafe) f.get(null);
+        } catch (Exception e) {
+            throw new IllegalStateException(UnsafeUtils.class.getSimpleName() + " can't acquire needed Unsafe access");
+        }
+    }
+
+    private static Field getBufferAddressField() {
+        try {
+            var field = Buffer.class.getDeclaredField("address");
+            field.setAccessible(true);
+            return field;
+        } catch (NoSuchFieldException e) {
+            throw new IllegalStateException("Init failed, no 'address' in Buffer");
+        }
+    }
+
+    public static long getDirectBufferAddress(ByteBuffer byteBuffer) {
+        try {
+            return (long) ADDRESS_FIELD.get(byteBuffer);
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException("Get address of byteBuffer failed");
+        }
+    }
+
+    public static void getBytes(long srcAddr, byte[] dst, long dstOffset, long length) {
+        if ((dstOffset | length | (dstOffset + length) | (dst.length - (dstOffset + length))) < 0) {
+            throw new IndexOutOfBoundsException(String.format(Locale.ROOT, "arraySize:%d, offset:%d, len:%d", dst.length, dstOffset, length));
+        }
+        long offset = BYTE_ARRAY_BASE_OFFSET + dstOffset;
+        while (length > 0) {
+            long size = Math.min(length, UNSAFE_COPY_THRESHOLD);
+            UNSAFE.copyMemory(null, srcAddr, dst, offset, size);
+            length -= size;
+            srcAddr += size;
+            offset += size;
+        }
+    }
+
+    public static void copyBytes(byte[] src, long srcOffset, long length, long targetAddr) {
+        if ((srcOffset | length | (src.length - (srcOffset + length))) < 0) {
+            throw new IndexOutOfBoundsException(String.format(Locale.ROOT, "arraySize:%d, offset:%d, len:%d", src.length, srcOffset, length));
+        }
+        long offset = BYTE_ARRAY_BASE_OFFSET + srcOffset;
+        UNSAFE.copyMemory(src, offset, null, targetAddr, length);
+    }
+}

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
@@ -69,7 +69,7 @@ public class SiftSmall {
             onDiskGraph = new CachingGraphIndex(new OnDiskGraphIndex<>(ReaderSupplierFactory.open(graphPath), 0));
 
             testRecallInternal(onHeapGraph, ravv, queryVectors, groundTruth, null);
-            testRecallInternal(onDiskGraph, null, queryVectors, groundTruth, compressedVectors);
+            testRecallInternal(onDiskGraph, ravv, queryVectors, groundTruth, compressedVectors);
         } finally {
             if (onDiskGraph!= null) {
                 onDiskGraph.close();

--- a/jvector-tests/pom.xml
+++ b/jvector-tests/pom.xml
@@ -84,6 +84,7 @@
                             <argLine>
                                 --add-modules=jdk.incubator.vector
                                 --enable-preview
+                                --add-opens java.base/java.nio=ALL-UNNAMED
                             </argLine>
                             <skip>${skipJdk20Tests}</skip>
                         </configuration>

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/microbench/PQBenchmark.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/microbench/PQBenchmark.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jbellis.jvector.microbench;
+
+import io.github.jbellis.jvector.TestUtil;
+import io.github.jbellis.jvector.graph.ListRandomAccessVectorValues;
+import io.github.jbellis.jvector.pq.PQVectors;
+import io.github.jbellis.jvector.pq.ProductQuantization;
+import org.openjdk.jmh.annotations.*;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
+
+import static io.github.jbellis.jvector.vector.VectorSimilarityFunction.EUCLIDEAN;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(warmups = 0, value = 1, jvmArgsAppend = {
+        "-XX:+UseG1GC",
+        "--add-opens",
+        "java.base/java.nio=ALL-UNNAMED",
+        "--add-modules=jdk.incubator.vector",
+        "--enable-preview",
+})
+public class PQBenchmark {
+
+    @Param("512")
+    public int dimension;
+
+    @Param("200000")
+    public int size;
+
+    @Param("4")
+    public int pqFactor;
+
+    @Param("32")
+    public int core;
+
+    private Random random;
+    private ProductQuantization pq;
+    private List<float[]> floats;
+    private float[] queryTestVector;
+    private ForkJoinPool fjp;
+    private PQVectors heapPqVectors;
+    private PQVectors offHeapPqVectors;
+
+    @Setup(Level.Trial)
+    public void setUp() {
+        long startTime = System.nanoTime();
+        fjp = new ForkJoinPool(core);
+        Random random = new Random();
+        random.setSeed(0);
+        floats = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            floats.add(TestUtil.randomVector(random, dimension));
+        }
+        int pqDims = dimension / pqFactor;
+        pq = ProductQuantization.compute(new ListRandomAccessVectorValues(floats, dimension), pqDims, false, fjp, fjp);
+        System.out.println("setup use time: " + (System.nanoTime() - startTime) / 1000000.0 + "ms");
+        byte[][] compressedVectors = pq.encodeAll(floats, fjp);
+        heapPqVectors = new PQVectors(pq, compressedVectors);
+        offHeapPqVectors = new PQVectors(pq, toDirectByteBuffer(compressedVectors), size);
+        queryTestVector = TestUtil.randomVector(random, dimension);
+    }
+
+    private static ByteBuffer toDirectByteBuffer(byte[][] compressedVectors) {
+        ByteBuffer cv = ByteBuffer.allocateDirect(compressedVectors.length * compressedVectors[0].length).order(ByteOrder.LITTLE_ENDIAN);
+        for (byte[] bytes : compressedVectors) {
+            cv.put(bytes);
+        }
+        cv.flip();
+        return cv;
+    }
+
+    @Benchmark
+    public byte[][] buildOnHeap() {
+        return pq.encodeAll(floats, fjp);
+    }
+
+    @Benchmark
+    public ByteBuffer buildOffHeap() {
+        return pq.encodeAllToOffHeap(floats, fjp);
+    }
+
+    @Benchmark
+    public float scoreHeap() {
+        float maxScore = -1;
+        var scoreFunction = heapPqVectors.approximateScoreFunctionFor(queryTestVector, EUCLIDEAN);
+        for (int i = 0; i < size; i++) {
+            float score = scoreFunction.similarityTo(i);
+            if (score > maxScore) {
+                maxScore = score;
+            }
+        }
+        return maxScore;
+    }
+
+    @Benchmark
+    public float scoreOffHeap() {
+        float maxScore = -1;
+        var scoreFunction = offHeapPqVectors.approximateScoreFunctionFor(queryTestVector, EUCLIDEAN);
+        for (int i = 0; i < size; i++) {
+            float score = scoreFunction.similarityTo(i);
+            if (score > maxScore) {
+                maxScore = score;
+            }
+        }
+        return maxScore;
+    }
+
+    public static void main(String[] args) throws IOException {
+        org.openjdk.jmh.Main.main(new String[]{PQBenchmark.class.getName()});
+    }
+}


### PR DESCRIPTION
Hi, I've added a feature about pq in off-heap.

In distributed systems implemented in Java, especially in vector scenarios, the memory is very limited, especially the memory in the Java heap, which may cause some gc problems. Therefore, we hope to put some objects into Java off-heap memory, so we first tried to modify it in PQ, and achieved good results.

As shown in the figure below, testing on the latest Dragonwell 11JDK (with java vector api), we found that the query performance can be greatly improved 26%, while the write performance has almost no change.
![image](https://github.com/jbellis/jvector/assets/23448336/5a0e05ba-8e34-4516-8fd0-35bbabab57da)

As shown in the figure below, on OpenJDK version 21.0.1, query performance is still greatly improved 23%.
![image](https://github.com/jbellis/jvector/assets/23448336/83ba3e71-89af-4a65-8de8-efcdcd57dc57)

In fact, what we initially focused on was not performance, but memory issues. Under the LSM-Tree architecture, a PQ or Graph object does not live long, but will cause a long GC. GC will cause writing or query glitches, so We want to put PQ outside the heap to reduce glitches. Not only can it be placed in off-heap memory after building, but it can also be placed directly in off-heap memory during the build process, which will greatly reduce the memory management pressure of the JVM.

The current implementation of Graph is relatively complex and does not have the ability to build outside the heap for the time being. It involves a lot of float and bytes conversion overhead. When I have time later, I will also try to test the performance of Graph implemented outside the heap in the Graph query phase.

Thanks for considering this PR. I'm open to any feedback or suggestions for improvements.