### PR TITLE
Corrected relative path to access Siftsmall example files

### DIFF
--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
@@ -118,7 +118,7 @@ public class SiftSmall {
     }
 
     public static void main(String[] args) throws IOException, ExecutionException, InterruptedException {
-        var siftPath = "siftsmall";
+        var siftPath = "jvector/siftsmall";
         var baseVectors = SiftLoader.readFvecs(String.format("%s/siftsmall_base.fvecs", siftPath));
         var queryVectors = SiftLoader.readFvecs(String.format("%s/siftsmall_query.fvecs", siftPath));
         var groundTruth = SiftLoader.readIvecs(String.format("%s/siftsmall_groundtruth.ivecs", siftPath));


### PR DESCRIPTION
the current path throws IO exception since there has been folder restructuring. Updated the path so SiftLoader.readFvecs does not throw FIleNotFound IO exception