### PR TITLE
add a diverseBefore marker to avoid recomputing diversity that hasn't changed

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ConcurrentNeighborSet.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ConcurrentNeighborSet.java
@@ -241,7 +241,10 @@ public class ConcurrentNeighborSet {
 
     private BitSet selectDiverse(NodeArray neighbors, int diverseBefore) {
         BitSet selected = new FixedBitSet(neighbors.size());
-        int nSelected = 0;
+        for (int i = 0; i < diverseBefore; i++) {
+            selected.set(i);
+        }
+        int nSelected = diverseBefore;
 
         // add diverse candidates, gradually increasing alpha to the threshold
         // (so that the nearest candidates are prioritized)
@@ -382,7 +385,7 @@ public class ConcurrentNeighborSet {
     }
 
     // is the candidate node with the given score closer to the base node than it is to any of the
-    // existing neighbors
+    // already-selected neighbors
     private boolean isDiverse(int node, float score, NodeArray others, BitSet selected, float alpha) {
         if (others.size() == 0) {
             return true;

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ConcurrentNeighborSet.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ConcurrentNeighborSet.java
@@ -370,13 +370,11 @@ public class ConcurrentNeighborSet {
 
             // batch up the enforcement of the max connection limit, since otherwise
             // we do a lot of duplicate work scanning nodes that we won't remove
-            int nextDiverseBefore;
+            int nextDiverseBefore = min(insertionPoint, old.diverseBefore);
             var hardMax = overflow * maxConnections;
             if (nextNodes.size > hardMax) {
-                nextNodes = removeAllNonDiverse(nextNodes, old.diverseBefore);
+                nextNodes = removeAllNonDiverse(nextNodes, nextDiverseBefore);
                 nextDiverseBefore = nextNodes.size;
-            } else {
-                nextDiverseBefore = min(insertionPoint, old.diverseBefore);
             }
 
             return new Neighbors(nextNodes, nextDiverseBefore);

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
@@ -45,7 +45,6 @@ import java.util.stream.IntStream;
 import static io.github.jbellis.jvector.util.DocIdSetIterator.NO_MORE_DOCS;
 import static io.github.jbellis.jvector.vector.VectorUtil.dotProduct;
 import static java.lang.Math.abs;
-import static java.lang.Math.sqrt;
 
 /**
  * Builder for Concurrent GraphIndex. See {@link GraphIndex} for a high level overview, and the
@@ -290,7 +289,7 @@ public class GraphIndexBuilder {
             var neighborNode = neighbors.node[i];
             var neighborScore = neighbors.score[i];
             if (connectionTargets.add(neighborNode)) {
-                graph.getNeighbors(neighborNode).insertNotDiverse(node, neighborScore, true);
+                graph.getNeighbors(neighborNode).insertNotDiverse(node, neighborScore);
                 return true;
             }
         }
@@ -485,7 +484,7 @@ public class GraphIndexBuilder {
                         break;
                     }
                 }
-                neighbors.padWithRandom(randomConnections);
+                neighbors.padWith(randomConnections);
             }
         }
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeArray.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeArray.java
@@ -74,15 +74,15 @@ public class NodeArray {
      * Add a new node to the NodeArray into a correct sort position according to its score.
      * Duplicate node + score pairs are ignored.
      *
-     * @return true if the new node + score pair did not already exist
+     * @return the insertion point of the new node, or -1 if it already existed
      */
-    public boolean insertSorted(int newNode, float newScore) {
+    public int insertSorted(int newNode, float newScore) {
         if (size == node.length) {
             growArrays();
         }
         int insertionPoint = descSortFindRightMostInsertionPoint(newScore);
         if (duplicateExistsNear(insertionPoint, newNode, newScore)) {
-            return false;
+            return -1;
         }
 
         System.arraycopy(node, insertionPoint, node, insertionPoint + 1, size - insertionPoint);
@@ -90,7 +90,7 @@ public class NodeArray {
         node[insertionPoint] = newNode;
         score[insertionPoint] = newScore;
         ++size;
-        return true;
+        return insertionPoint;
     }
 
     private boolean duplicateExistsNear(int insertionPoint, int newNode, float newScore) {


### PR DESCRIPTION
this makes backlink() about 10% faster since most of its cost comes when it has to call removeAllNonDiverse