### PR TITLE
GraphIndexBuilder implements Closeable instead of AutoCloseable

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphSearcher.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphSearcher.java
@@ -34,6 +34,8 @@ import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import org.agrona.collections.IntHashSet;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Comparator;
 
@@ -42,7 +44,7 @@ import java.util.Comparator;
  * Searches a graph to find nearest neighbors to a query vector. For more background on the
  * search algorithm, see {@link GraphIndex}.
  */
-public class GraphSearcher implements AutoCloseable {
+public class GraphSearcher implements Closeable {
     private final GraphIndex.View view;
 
     // Scratch data structures that are used in each {@link #searchInternal} call. These can be expensive
@@ -352,7 +354,7 @@ public class GraphSearcher implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() throws IOException {
         view.close();
     }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/InlineVectorValues.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/InlineVectorValues.java
@@ -17,6 +17,7 @@
 package io.github.jbellis.jvector.graph.disk;
 
 import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
+import io.github.jbellis.jvector.util.ExceptionUtils;
 import io.github.jbellis.jvector.util.ExplicitThreadLocal;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
@@ -76,6 +77,10 @@ public class InlineVectorValues implements RandomAccessVectorValues, Closeable {
 
     @Override
     public void close() throws IOException {
-        sources.close();
+        try {
+            sources.close();
+        } catch (Exception e) {
+            ExceptionUtils.throwIoException(e);
+        }
     }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/LvqVectorValues.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/LvqVectorValues.java
@@ -18,6 +18,7 @@ package io.github.jbellis.jvector.graph.disk;
 
 import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
 import io.github.jbellis.jvector.pq.LocallyAdaptiveVectorQuantization;
+import io.github.jbellis.jvector.util.ExceptionUtils;
 import io.github.jbellis.jvector.util.ExplicitThreadLocal;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 
@@ -72,7 +73,11 @@ public class LvqVectorValues implements RandomAccessVectorValues, Closeable {
 
     @Override
     public void close() throws IOException {
-        sources.close();
+        try {
+            sources.close();
+        } catch (Exception e) {
+            ExceptionUtils.throwIoException(e);
+        }
     }
 
     private static class CloseablePackedVectors implements LVQPackedVectors, Closeable {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/ExceptionUtils.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/ExceptionUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.util;
+
+import java.io.IOException;
+
+public class ExceptionUtils {
+    public static void throwIoException(Throwable t) throws IOException {
+        if (t instanceof RuntimeException) {
+            throw (RuntimeException) t;
+        } else if (t instanceof Error) {
+            throw (Error) t;
+        } else if (t instanceof IOException) {
+            throw (IOException) t;
+        } else {
+            throw new RuntimeException(t);
+        }
+    }
+}

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/ExplicitThreadLocal.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/ExplicitThreadLocal.java
@@ -58,14 +58,10 @@ public abstract class ExplicitThreadLocal<U> implements AutoCloseable {
      * Not threadsafe.
      */
     @Override
-    public void close() {
+    public void close() throws Exception {
         for (U value : map.values()) {
             if (value instanceof AutoCloseable) {
-                try {
-                    ((AutoCloseable) value).close();
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
+                ((AutoCloseable) value).close();
             }
         }
         map.clear();

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
@@ -135,6 +135,8 @@ public class Grid {
                 indexes.forEach((features, index) -> {
                     try (var cs = new ConfiguredSystem(ds, index, cv)) {
                         testConfiguration(cs, efSearchOptions);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
                     }
                 });
             }
@@ -429,7 +431,7 @@ public class Grid {
         }
 
         @Override
-        public void close() {
+        public void close() throws Exception {
             searchers.close();
         }
     }


### PR DESCRIPTION
I'm kind of on the fence here

I hate dancing with checked exceptions, but I do think it's a good thing to make GraphIndexBuilder more specific in its signature