### PR TITLE
remove BQ centering

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -73,6 +73,8 @@ If you only read one thing, read this!
 ## Other changes to public classes
 - `FixedBitSet.nextSetBit` behaves as expected
 - Removed vestigal references to node level in several places that were left over from old HNSW code
+- Centering of binary quantization makes things worse, not better, and has been removed.  Saved BQ and BQVectors
+  that have centering data will ignore it on load.
 
 # Upgrading from 1.0.x to 2.0.x
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/BQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/BQVectors.java
@@ -96,6 +96,10 @@ public class BQVectors implements CompressedVectors {
         return scoreFunctionFor(q, similarityFunction);
     }
 
+    /**
+     * Note that `similarityFunction` is ignored, you always get Hamming distance similarity with BQ, which
+     * is a useful approximation for cosine distance and not really anything else.
+     */
     @Override
     public ScoreFunction.ApproximateScoreFunction scoreFunctionFor(VectorFloat<?> q, VectorSimilarityFunction similarityFunction) {
         var qBQ = bq.encode(q);

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/BQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/BQVectors.java
@@ -101,8 +101,12 @@ public class BQVectors implements CompressedVectors {
         var qBQ = bq.encode(q);
         return node2 -> {
             var vBQ = compressedVectors[node2];
-            return 1 - (float) VectorUtil.hammingDistance(qBQ, vBQ) / q.length();
+            return similarityBetween(qBQ, vBQ);
         };
+    }
+
+    public float similarityBetween(long[] encoded1, long[] encoded2) {
+        return 1 - (float) VectorUtil.hammingDistance(encoded1, encoded2) / bq.getOriginalDimension();
     }
 
     public long[] get(int i) {

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Bench.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Bench.java
@@ -51,7 +51,7 @@ public class Bench {
         );
         List<Function<DataSet, CompressorParameters>> searchCompression = Arrays.asList(
                 __ -> CompressorParameters.NONE,
-                // ds -> BinaryQuantization.compute(ds.getBaseRavv()),
+                // ds -> new CompressorParameters.BQParameters(),
                 ds -> new PQParameters(ds.getDimension() / 8, 256, ds.similarityFunction == VectorSimilarityFunction.EUCLIDEAN, UNWEIGHTED)
         );
         List<EnumSet<FeatureId>> featureSets = Arrays.asList(

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/CompressorParameters.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/CompressorParameters.java
@@ -66,7 +66,7 @@ public abstract class CompressorParameters {
     public static class BQParameters extends CompressorParameters {
         @Override
         public VectorCompressor<?> computeCompressor(DataSet ds) {
-            return BinaryQuantization.compute(ds.getBaseRavv());
+            return new BinaryQuantization(ds.getDimension());
         }
     }
 

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/pq/TestCompressedVectors.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/pq/TestCompressedVectors.java
@@ -65,8 +65,8 @@ public class TestCompressedVectors extends RandomizedTest {
     public void testSaveLoadBQ() throws Exception {
         // Generate a PQ for random vectors
         var vectors = createRandomVectors(512, 64);
-        var ravv = new ListRandomAccessVectorValues(vectors, 2);
-        var bq = BinaryQuantization.compute(ravv);
+        var ravv = new ListRandomAccessVectorValues(vectors, 64);
+        var bq = new BinaryQuantization(ravv.dimension());
 
         // Compress the vectors
         var compressed = bq.encodeAll(ravv);

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/pq/TestProductQuantization.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/pq/TestProductQuantization.java
@@ -32,8 +32,10 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -247,5 +249,37 @@ public class TestProductQuantization extends RandomizedTest {
         var contents1 = Files.readAllBytes(fileIn.toPath());
         var contents2 = Files.readAllBytes(fileOut.toPath());
         assertArrayEquals(contents1, contents2);
+    }
+
+    @Test
+    public void testBqCentering() {
+        // vectors all in the top right quadrant of the unit circle
+        var R = ThreadLocalRandom.current();
+        var L = new ArrayList<VectorFloat<?>>();
+        for (int i = 0; i < 100; i++) {
+            var v = vectorTypeSupport.createFloatVector(new float[] {R.nextFloat(), R.nextFloat()});
+            VectorUtil.l2normalize(v);
+            L.add(v);
+        }
+
+        var bq = new BinaryQuantization(vectorTypeSupport.createFloatVector(2));
+        assertAllEqual(bq, L); // passes
+
+        var center = VectorUtil.sum(L);
+        VectorUtil.scale(center, 1.0f / L.size());
+        var bq2 = new BinaryQuantization(center);
+        assertAllEqual(bq2, L); // fails with about 5000 (half the pairs)
+    }
+
+    private static void assertAllEqual(BinaryQuantization bq, ArrayList<VectorFloat<?>> L) {
+        var compressed = bq.encodeAll(new ListRandomAccessVectorValues(L, 2));
+        var bqv = new BQVectors(bq, compressed);
+        float loss = 0;
+        for (int i = 0; i < 100; i++) {
+            for (int j = 0; j < 100; j++) {
+                loss += bqv.similarityBetween(bqv.get(i), bqv.get(j));
+            }
+        }
+        assertEquals(100 * 100, loss, 1E-6);
     }
 }

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/pq/TestProductQuantization.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/pq/TestProductQuantization.java
@@ -250,36 +250,4 @@ public class TestProductQuantization extends RandomizedTest {
         var contents2 = Files.readAllBytes(fileOut.toPath());
         assertArrayEquals(contents1, contents2);
     }
-
-    @Test
-    public void testBqCentering() {
-        // vectors all in the top right quadrant of the unit circle
-        var R = ThreadLocalRandom.current();
-        var L = new ArrayList<VectorFloat<?>>();
-        for (int i = 0; i < 100; i++) {
-            var v = vectorTypeSupport.createFloatVector(new float[] {R.nextFloat(), R.nextFloat()});
-            VectorUtil.l2normalize(v);
-            L.add(v);
-        }
-
-        var bq = new BinaryQuantization(vectorTypeSupport.createFloatVector(2));
-        assertAllEqual(bq, L); // passes
-
-        var center = VectorUtil.sum(L);
-        VectorUtil.scale(center, 1.0f / L.size());
-        var bq2 = new BinaryQuantization(center);
-        assertAllEqual(bq2, L); // fails with about 5000 (half the pairs)
-    }
-
-    private static void assertAllEqual(BinaryQuantization bq, ArrayList<VectorFloat<?>> L) {
-        var compressed = bq.encodeAll(new ListRandomAccessVectorValues(L, 2));
-        var bqv = new BQVectors(bq, compressed);
-        float loss = 0;
-        for (int i = 0; i < 100; i++) {
-            for (int j = 0; j < 100; j++) {
-                loss += bqv.similarityBetween(bqv.get(i), bqv.get(j));
-            }
-        }
-        assertEquals(100 * 100, loss, 1E-6);
-    }
 }


### PR DESCRIPTION
First commit adds a test demonstrating that centering is counterproductive for BQ

Second commit removes BQ centering

I wasn't sure what to do about backwards compatibility but I decided to just ignore the centering from old BQ since if it's working at all it must be the case that your center is effectively zero anyway (which it is for our test datasets that are ~uniformly distributed across a unit hypersphere).