### PR TITLE
Fix writing jvector2-compatible indexes incrementally

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/CommonHeader.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/CommonHeader.java
@@ -41,6 +41,7 @@ class CommonHeader {
 
     void write(DataOutput out) throws IOException {
         if (version >= 3) {
+            out.writeInt(OnDiskGraphIndex.MAGIC);
             out.writeInt(version);
         }
         out.writeInt(size);
@@ -50,8 +51,16 @@ class CommonHeader {
     }
 
     static CommonHeader load(RandomAccessReader reader) throws IOException {
-        int version = reader.readInt();
-        int size = reader.readInt();
+        int maybeMagic = reader.readInt();
+        int version;
+        int size;
+        if (maybeMagic == OnDiskGraphIndex.MAGIC) {
+            version = reader.readInt();
+            size = reader.readInt();
+        } else {
+            version = 2;
+            size = maybeMagic;
+        }
         int dimension = reader.readInt();
         int entryNode = reader.readInt();
         int maxDegree = reader.readInt();
@@ -59,7 +68,7 @@ class CommonHeader {
         return new CommonHeader(version, size, dimension, entryNode, maxDegree);
     }
 
-    static int size() {
-        return 5 * Integer.BYTES;
+    int size() {
+        return ((version >= 3 ? 2 : 0) + 4) * Integer.BYTES;
     }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
@@ -86,8 +86,8 @@ public class OnDiskGraphIndex implements GraphIndex, AutoCloseable, Accountable
      */
     public static OnDiskGraphIndex load(ReaderSupplier readerSupplier, long offset) {
         try (var reader = readerSupplier.get()) {
-            var info = Header.load(reader, offset);
-            return new OnDiskGraphIndex(readerSupplier, info, reader.getPosition());
+            var header = Header.load(reader, offset);
+            return new OnDiskGraphIndex(readerSupplier, header, reader.getPosition());
         } catch (Exception e) {
             throw new RuntimeException("Error initializing OnDiskGraph at offset " + offset, e);
         }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
@@ -16,6 +16,7 @@
 
 package io.github.jbellis.jvector.graph.disk;
 
+import io.github.jbellis.jvector.annotations.VisibleForTesting;
 import io.github.jbellis.jvector.disk.RandomAccessReader;
 import io.github.jbellis.jvector.disk.ReaderSupplier;
 import io.github.jbellis.jvector.graph.GraphIndex;
@@ -296,5 +297,14 @@ public class OnDiskGraphIndex implements GraphIndex, AutoCloseable, Accountable
                                                        nodeId -> new InlineVectors.State(vectors.getVector(nodeId)));
             writer.write(suppliers);
         }
+    }
+
+    @VisibleForTesting
+    static boolean areHeadersEqual(OnDiskGraphIndex g1, OnDiskGraphIndex g2) {
+        return g1.version == g2.version &&
+               g1.size == g2.size &&
+               g1.maxDegree == g2.maxDegree &&
+               g1.dimension == g2.dimension &&
+               g1.entryNode == g2.entryNode;
     }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndexWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndexWriter.java
@@ -213,8 +213,7 @@ public class OnDiskGraphIndexWriter implements Closeable {
                 var supplier = featureStateSuppliers.get(feature.id());
                 if (supplier == null) {
                     out.seek(out.position() + feature.inlineSize());
-                }
-                else {
+                } else {
                     feature.writeInline(out, supplier.apply(originalOrdinal));
                 }
             }

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskGraphIndex.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskGraphIndex.java
@@ -197,7 +197,7 @@ public class TestOnDiskGraphIndex extends RandomizedTest {
              var onDiskView = onDiskGraph.getView())
         {
             assertEquals(32, onDiskGraph.maxDegree);
-            assertEquals(0, onDiskGraph.version);
+            assertEquals(2, onDiskGraph.version);
             assertEquals(100_000, onDiskGraph.size);
             assertEquals(2, onDiskGraph.dimension);
             assertEquals(99779, onDiskGraph.entryNode);
@@ -255,10 +255,9 @@ public class TestOnDiskGraphIndex extends RandomizedTest {
                 var state = Feature.singleState(FeatureId.INLINE_VECTORS, new InlineVectors.State(ravv.getVector(i)));
                 writer.writeInline(i, state);
             }
-            var suppliers = new EnumMap<FeatureId, IntFunction<Feature.State>>(FeatureId.class);
-            suppliers.put(FeatureId.INLINE_VECTORS, null);
-            suppliers.put(FeatureId.FUSED_ADC, i -> new FusedADC.State(graph.getView(), pqv, i));
-            writer.write(suppliers); // write graph structure, fused ADC
+            // write graph structure, fused ADC
+            writer.write(Feature.singleStateFactory(FeatureId.FUSED_ADC, i -> new FusedADC.State(graph.getView(), pqv, i)));
+            writer.write(Map.of());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
    getOffsetForOrdinal (renamed featureOffsetForOrdinal) needs to be aware that header size depends on version.
    
    add testV0WriteIncremental to demonstrate the issue.
    
    Least error-prone solution is to push size() into Header and CommonHeader.  This in turn means that MAGIC and versioning should be the responsibility of CommonHeader, rather than Header.
