### PR TITLE
improve memory usage during construction

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ConcurrentNeighborSet.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ConcurrentNeighborSet.java
@@ -23,6 +23,7 @@ import io.github.jbellis.jvector.util.BitSet;
 import io.github.jbellis.jvector.util.Bits;
 import io.github.jbellis.jvector.util.DocIdSetIterator;
 import io.github.jbellis.jvector.util.FixedBitSet;
+import io.github.jbellis.jvector.util.RamUsageEstimator;
 
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntFunction;
@@ -359,6 +360,22 @@ public class ConcurrentNeighborSet {
 
             return new Neighbors(nextNodes, nextDiverseBefore);
         });
+    }
+
+    public static long ramBytesUsed(int nodes) {
+        int REF_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+        int OH_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_HEADER;
+        int AREF_BYTES = OH_BYTES + 2 * REF_BYTES;
+
+        return OH_BYTES
+                + REF_BYTES + AREF_BYTES // Neighbors AtomicReference
+                + OH_BYTES + REF_BYTES + Integer.BYTES // Neighbors
+                + NodeArray.ramBytesUsed(nodes) // NodeArray
+                + Float.BYTES // alpha
+                + REF_BYTES // BSP
+                + Integer.BYTES // maxDegree
+                + Integer.BYTES // maxOverflowDegree
+                + Float.BYTES; // shortEdges
     }
 
     /** Only for testing; this is a linear search */

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeArray.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeArray.java
@@ -222,7 +222,15 @@ public class NodeArray {
     }
 
     public NodeArray copy() {
-        NodeArray copy = new NodeArray(node.length);
+        return copy(size);
+    }
+
+    public NodeArray copy(int newSize) {
+        if (size > newSize) {
+            throw new IllegalArgumentException("Cannot copy to a smaller size");
+        }
+
+        NodeArray copy = new NodeArray(newSize);
         copy.size = size;
         System.arraycopy(node, 0, copy.node, 0, size);
         System.arraycopy(score, 0, copy.score, 0, size);

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeArray.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeArray.java
@@ -27,6 +27,7 @@ package io.github.jbellis.jvector.graph;
 import io.github.jbellis.jvector.annotations.VisibleForTesting;
 import io.github.jbellis.jvector.util.ArrayUtil;
 import io.github.jbellis.jvector.util.Bits;
+import io.github.jbellis.jvector.util.RamUsageEstimator;
 import org.agrona.collections.IntHashSet;
 
 import java.util.Arrays;
@@ -285,6 +286,18 @@ public class NodeArray {
             else start = mid + 1;
         }
         return start;
+    }
+
+    public static long ramBytesUsed(int size) {
+        int REF_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+        int AH_BYTES = RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
+        int OH_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_HEADER;
+
+        return OH_BYTES
+                + Integer.BYTES // size field
+                + REF_BYTES + AH_BYTES // nodes array
+                + REF_BYTES + AH_BYTES // scores array
+                + (long) size * (Integer.BYTES + Float.BYTES); // array contents
     }
 
     /**

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
@@ -53,11 +53,13 @@ public class OnHeapGraphIndex implements GraphIndex {
 
     // max neighbors/edges per node
     final int maxDegree;
+    private final int maxOverflowDegree;
     private final BiFunction<Integer, Integer, ConcurrentNeighborSet> neighborFactory;
 
-    OnHeapGraphIndex(int M, BiFunction<Integer, Integer, ConcurrentNeighborSet> neighborFactory) {
-        this.neighborFactory = neighborFactory;
+    OnHeapGraphIndex(int M, int maxOverflowDegree, BiFunction<Integer, Integer, ConcurrentNeighborSet> neighborFactory) {
         this.maxDegree = M;
+        this.maxOverflowDegree = maxOverflowDegree;
+        this.neighborFactory = neighborFactory;
         this.nodes = new DenseIntMap<>(1024);
     }
 
@@ -146,13 +148,13 @@ public class OnHeapGraphIndex implements GraphIndex {
     public long ramBytesUsed() {
         // the main graph structure
         long total = (long) size() * RamUsageEstimator.NUM_BYTES_OBJECT_REF;
-        long neighborSize = neighborsRamUsed(maxDegree()) * size();
+        long neighborSize = neighborsRamUsed(maxOverflowDegree) * size();
         return total + neighborSize + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
     }
 
     public long ramBytesUsedOneNode() {
         var graphBytesUsed =
-                neighborsRamUsed(maxDegree());
+                neighborsRamUsed(maxOverflowDegree);
         var clockBytesUsed = Integer.BYTES;
         return graphBytesUsed + clockBytesUsed;
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/PQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/PQVectors.java
@@ -219,13 +219,14 @@ public class PQVectors implements CompressedVectors {
 
     @Override
     public long ramBytesUsed() {
-        long codebooksSize = pq.memorySize();
-        if (compressedVectors.isEmpty()) {
-            return codebooksSize;
-        }
+        int REF_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+        int OH_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_HEADER;
+        int AH_BYTES = RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
 
-        long compressedVectorSize = RamUsageEstimator.sizeOf(compressedVectors.get(0));
-        return codebooksSize + (compressedVectorSize * compressedVectors.size());
+        long codebooksSize = pq.ramBytesUsed();
+        long listSize = (long) REF_BYTES * (1 + compressedVectors.size());
+        long dataSize = (long) (OH_BYTES + AH_BYTES + pq.compressedVectorSize()) * compressedVectors.size();
+        return codebooksSize + listSize + dataSize;
     }
 
     @Override

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/ProductQuantization.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/ProductQuantization.java
@@ -20,6 +20,7 @@ import io.github.jbellis.jvector.annotations.VisibleForTesting;
 import io.github.jbellis.jvector.disk.RandomAccessReader;
 import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
+import io.github.jbellis.jvector.util.Accountable;
 import io.github.jbellis.jvector.util.PhysicalCoreExecutor;
 import io.github.jbellis.jvector.vector.VectorUtil;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
@@ -49,7 +50,7 @@ import static java.lang.Math.sqrt;
  * Product Quantization for float vectors.  Supports arbitrary source and target dimensionality;
  * in particular, the source does not need to be evenly divisible by the target.
  */
-public class ProductQuantization implements VectorCompressor<ByteSequence<?>> {
+public class ProductQuantization implements VectorCompressor<ByteSequence<?>>, Accountable {
     private static final int MAGIC = 0x75EC4012; // JVECTOR, with some imagination
 
     private static final VectorTypeSupport vectorTypeSupport = VectorizationProvider.getInstance().getVectorTypeSupport();
@@ -685,7 +686,8 @@ public class ProductQuantization implements VectorCompressor<ByteSequence<?>> {
         return codebooks.length;
     }
 
-    public long memorySize() {
+    @Override
+    public long ramBytesUsed() {
         long size = 0;
         for (VectorFloat<?> codebook : codebooks) {
             size += codebook.ramBytesUsed();

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArrayByteSequence.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArrayByteSequence.java
@@ -74,7 +74,8 @@ final public class ArrayByteSequence implements ByteSequence<byte[]>
 
     @Override
     public long ramBytesUsed() {
-        return RamUsageEstimator.sizeOf(data) + RamUsageEstimator.shallowSizeOfInstance(ByteSequence.class);
+        int OH_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_HEADER;
+        return OH_BYTES + RamUsageEstimator.sizeOf(data);
     }
 
     @Override

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArrayVectorFloat.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArrayVectorFloat.java
@@ -81,7 +81,8 @@ final public class ArrayVectorFloat implements VectorFloat<float[]>
     @Override
     public long ramBytesUsed()
     {
-        return RamUsageEstimator.sizeOf(data) + RamUsageEstimator.shallowSizeOfInstance(ArrayVectorFloat.class);
+        int OH_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_HEADER;
+        return OH_BYTES + RamUsageEstimator.sizeOf(data);
     }
 
     @Override

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/MemorySegmentByteSequence.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/MemorySegmentByteSequence.java
@@ -16,6 +16,7 @@
 
 package io.github.jbellis.jvector.vector;
 
+import io.github.jbellis.jvector.util.RamUsageEstimator;
 import io.github.jbellis.jvector.vector.types.ByteSequence;
 
 import java.lang.foreign.MemoryLayout;
@@ -50,7 +51,9 @@ public class MemorySegmentByteSequence implements ByteSequence<MemorySegment> {
 
     @Override
     public long ramBytesUsed() {
-        return MemoryLayout.sequenceLayout(length, ValueLayout.JAVA_BYTE).byteSize();
+        int OH_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_HEADER;
+        int REF_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+        return OH_BYTES + REF_BYTES + Integer.BYTES + MemoryLayout.sequenceLayout(length, ValueLayout.JAVA_BYTE).byteSize();
     }
 
     @Override

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/MemorySegmentVectorFloat.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/MemorySegmentVectorFloat.java
@@ -16,6 +16,7 @@
 
 package io.github.jbellis.jvector.vector;
 
+import io.github.jbellis.jvector.util.RamUsageEstimator;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 
 import java.lang.foreign.MemorySegment;
@@ -44,7 +45,9 @@ final public class MemorySegmentVectorFloat implements VectorFloat<MemorySegment
     @Override
     public long ramBytesUsed()
     {
-        return segment.byteSize();
+        int OH_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_HEADER;
+        int REF_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+        return OH_BYTES + REF_BYTES + segment.byteSize();
     }
 
     @Override

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestConcurrentNeighborSet.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestConcurrentNeighborSet.java
@@ -102,7 +102,7 @@ public class TestConcurrentNeighborSet extends RandomizedTest {
     var cna2 = new NodeArray(1);
     cna2.addInOrder(8, scoreBetween(bsp, 7, 6));
 
-    var neighbors = new ConcurrentNeighborSet(7, 3, bsp, 1.0f, cna);
+    var neighbors = new ConcurrentNeighborSet(7, 3, 3, bsp, 1.0f, cna);
     neighbors.insertDiverse(cna2);
     assertEquals(2, neighbors.size());
   }


### PR DESCRIPTION
commit 2 does most of the work, the key is that when insert() or insertDiverse() is called, we copy the source nodes into a size-limited NodeArray instead of assuming that the source array is correctly sized.  commit 2 also inlines and removes removeAllNonDiverse to improve clarity, that method was the only one related to diversity that did internal copies which was a bit confusing.

commit 3 does some fairly mechanical improvements of ramBytesUsed; most methods were not including object headers which for the ones where we have millions of instances (CNS and ArrayByteSequence) becomes material