### PR TITLE
Ecapsulate NodeArray internals

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ConcurrentNeighborMap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ConcurrentNeighborMap.java
@@ -271,7 +271,10 @@ public class ConcurrentNeighborMap {
             assert size() <= maxDegree : "insertNotDiverse called before enforcing degree/diversity";
             var next = copy(maxDegree); // we are only called during cleanup -- use actual maxDegree not nodeArrayLength()
             int insertedAt = next.insertOrReplaceWorst(node, score);
-            assert insertedAt >= 0;
+            if (insertedAt == -1) {
+                // node already existed in the array -- this is rare enough that we don't check up front
+                return this;
+            }
             next.diverseBefore = min(insertedAt, diverseBefore);
             return next;
         }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ConcurrentNeighborMap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ConcurrentNeighborMap.java
@@ -159,8 +159,8 @@ public class ConcurrentNeighborMap {
      */
     public void backlink(NodeArray nodes, int toId, float overflow) {
         for (int i = 0; i < nodes.size(); i++) {
-            int nbr = nodes.node[i];
-            float nbrScore = nodes.score[i];
+            int nbr = nodes.getNode(i);
+            float nbrScore = nodes.getScore(i);
             insertOne(nbr, toId, nbrScore, overflow);
         }
     }
@@ -235,9 +235,9 @@ public class ConcurrentNeighborMap {
             // copy the non-deleted neighbors to a new NodeArray
             var liveNeighbors = new NodeArray(size());
             for (int i = 0; i < size(); i++) {
-                int nodeId = node[i];
+                int nodeId = getNode(i);
                 if (!deletedNodes.get(nodeId)) {
-                    liveNeighbors.addInOrder(nodeId, score[i]);
+                    liveNeighbors.addInOrder(nodeId, getScore(i));
                 }
             }
 
@@ -269,7 +269,7 @@ public class ConcurrentNeighborMap {
                 retainDiverse(merged, 0, map);
             }
             // insertDiverse usually gets called with a LOT of candidates, so trim down the resulting NodeArray
-            var nextNodes = merged.node.length <= map.nodeArrayLength() ? merged : merged.copy(map.nodeArrayLength());
+            var nextNodes = merged.getArrayLength() <= map.nodeArrayLength() ? merged : merged.copy(map.nodeArrayLength());
             return new Neighbors(nodeId, nextNodes);
         }
 
@@ -313,8 +313,8 @@ public class ConcurrentNeighborMap {
                         continue;
                     }
 
-                    int cNode = neighbors.node()[i];
-                    float cScore = neighbors.score()[i];
+                    int cNode = neighbors.getNode(i);
+                    float cScore = neighbors.getScore(i);
                     var sf = map.scoreProvider.diversityProviderFor(cNode).scoreFunction();
                     if (isDiverse(cNode, cScore, neighbors, sf, selected, a)) {
                         selected.set(i);
@@ -337,7 +337,7 @@ public class ConcurrentNeighborMap {
             assert others.size() > 0;
 
             for (int i = selected.nextSetBit(0); i != DocIdSetIterator.NO_MORE_DOCS; i = selected.nextSetBit(i + 1)) {
-                int otherNode = others.node()[i];
+                int otherNode = others.getNode(i);
                 if (node == otherNode) {
                     break;
                 }
@@ -423,7 +423,7 @@ public class ConcurrentNeighborMap {
 
         @Override
         public int nextInt() {
-            return neighbors.node[i++];
+            return neighbors.getNode(i++);
         }
     }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ConcurrentNeighborMap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ConcurrentNeighborMap.java
@@ -184,13 +184,6 @@ public class ConcurrentNeighborMap {
         /** entries in `nodes` before this index are diverse and don't need to be checked again */
         private int diverseBefore;
 
-        private Neighbors(int nodeId, int initialSize, int diverseBefore)
-        {
-            super(initialSize);
-            this.nodeId = nodeId;
-            this.diverseBefore = diverseBefore;
-        }
-
         /**
          * uses the node and score references directly from `nodeArray`, without copying
          * `nodeArray` is assumed to have had diversity enforced already

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
@@ -243,7 +243,7 @@ public class GraphIndexBuilder implements Closeable {
             connectedNodes.set(graph.entry());
             ConcurrentNeighborMap.Neighbors self1 = graph.getNeighbors(graph.entry());
             var entryNeighbors = (NodeArray) self1;
-            parallelExecutor.submit(() -> IntStream.range(0, entryNeighbors.size).parallel().forEach(node -> findConnected(connectedNodes, entryNeighbors.node[node]))).join();
+            parallelExecutor.submit(() -> IntStream.range(0, entryNeighbors.size()).parallel().forEach(node -> findConnected(connectedNodes, entryNeighbors.node[node]))).join();
 
             // reconnect unreachable nodes
             var nReconnected = new AtomicInteger();
@@ -293,7 +293,7 @@ public class GraphIndexBuilder implements Closeable {
         // connect this node to the closest neighbor that hasn't already been used as a connection target
         // (since this edge is likely to be the "worst" one in that target's neighborhood, it's likely to be
         // overwritten by the next node to need reconnection if we don't choose a unique target)
-        for (int i = 0; i < neighbors.size; i++) {
+        for (int i = 0; i < neighbors.size(); i++) {
             var neighborNode = neighbors.node[i];
             var neighborScore = neighbors.score[i];
             if (connectionTargets.add(neighborNode)) {
@@ -530,7 +530,7 @@ public class GraphIndexBuilder implements Closeable {
                             float score = sf.similarityTo(randomNode);
                             candidates.insertSorted(randomNode, score);
                         }
-                        if (candidates.size == graph.maxDegree) {
+                        if (candidates.size() == graph.maxDegree) {
                             break;
                         }
                     }
@@ -593,9 +593,9 @@ public class GraphIndexBuilder implements Closeable {
     private void updateNeighbors(int nodeId, NodeArray natural, NodeArray concurrent) {
         // if either natural or concurrent is empty, skip the merge
         NodeArray toMerge;
-        if (concurrent.size == 0) {
+        if (concurrent.size() == 0) {
             toMerge = natural;
-        } else if (natural.size == 0) {
+        } else if (natural.size() == 0) {
             toMerge = concurrent;
         } else {
             toMerge = NodeArray.merge(natural, concurrent);

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
@@ -243,7 +243,7 @@ public class GraphIndexBuilder implements Closeable {
             connectedNodes.set(graph.entry());
             ConcurrentNeighborMap.Neighbors self1 = graph.getNeighbors(graph.entry());
             var entryNeighbors = (NodeArray) self1;
-            parallelExecutor.submit(() -> IntStream.range(0, entryNeighbors.size()).parallel().forEach(node -> findConnected(connectedNodes, entryNeighbors.node[node]))).join();
+            parallelExecutor.submit(() -> IntStream.range(0, entryNeighbors.size()).parallel().forEach(node -> findConnected(connectedNodes, entryNeighbors.getNode(node)))).join();
 
             // reconnect unreachable nodes
             var nReconnected = new AtomicInteger();
@@ -294,8 +294,8 @@ public class GraphIndexBuilder implements Closeable {
         // (since this edge is likely to be the "worst" one in that target's neighborhood, it's likely to be
         // overwritten by the next node to need reconnection if we don't choose a unique target)
         for (int i = 0; i < neighbors.size(); i++) {
-            var neighborNode = neighbors.node[i];
-            var neighborScore = neighbors.score[i];
+            var neighborNode = neighbors.getNode(i);
+            var neighborScore = neighbors.getScore(i);
             if (connectionTargets.add(neighborNode)) {
                 graph.nodes.insertNotDiverse(neighborNode, node, neighborScore);
                 return true;

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeArray.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeArray.java
@@ -44,19 +44,19 @@ public class NodeArray {
     public static final NodeArray EMPTY = new NodeArray(0);
 
     private int size;
-    private float[] score;
-    private int[] node;
+    private float[] scores;
+    private int[] nodes;
 
     public NodeArray(int initialSize) {
-        node = new int[initialSize];
-        score = new float[initialSize];
+        nodes = new int[initialSize];
+        scores = new float[initialSize];
     }
 
     // this idiosyncratic constructor exists for the benefit of subclass ConcurrentNeighborMap
     protected NodeArray(NodeArray nodeArray) {
         this.size = nodeArray.size();
-        this.node = nodeArray.node;
-        this.score = nodeArray.score;
+        this.nodes = nodeArray.nodes;
+        this.scores = nodeArray.scores;
     }
 
     /** always creates a new NodeArray to return, even when a1 or a2 is empty */
@@ -72,37 +72,37 @@ public class NodeArray {
         // loop through both source arrays, adding the highest score element to the merged array,
         // until we reach the end of one of the sources
         while (i < a1.size() && j < a2.size()) {
-            if (a1.score[i] < a2.score[j]) {
+            if (a1.scores[i] < a2.scores[j]) {
                 // add from a2
-                if (a2.score[j] != lastAddedScore) {
+                if (a2.scores[j] != lastAddedScore) {
                     nodesWithLastScore.clear();
-                    lastAddedScore = a2.score[j];
+                    lastAddedScore = a2.scores[j];
                 }
-                if (nodesWithLastScore.add(a2.node[j])) {
-                    merged.addInOrder(a2.node[j], a2.score[j]);
+                if (nodesWithLastScore.add(a2.nodes[j])) {
+                    merged.addInOrder(a2.nodes[j], a2.scores[j]);
                 }
                 j++;
-            } else if (a1.score[i] > a2.score[j]) {
+            } else if (a1.scores[i] > a2.scores[j]) {
                 // add from a1
-                if (a1.score[i] != lastAddedScore) {
+                if (a1.scores[i] != lastAddedScore) {
                     nodesWithLastScore.clear();
-                    lastAddedScore = a1.score[i];
+                    lastAddedScore = a1.scores[i];
                 }
-                if (nodesWithLastScore.add(a1.node[i])) {
-                    merged.addInOrder(a1.node[i], a1.score[i]);
+                if (nodesWithLastScore.add(a1.nodes[i])) {
+                    merged.addInOrder(a1.nodes[i], a1.scores[i]);
                 }
                 i++;
             } else {
                 // same score -- add both
-                if (a1.score[i] != lastAddedScore) {
+                if (a1.scores[i] != lastAddedScore) {
                     nodesWithLastScore.clear();
-                    lastAddedScore = a1.score[i];
+                    lastAddedScore = a1.scores[i];
                 }
-                if (nodesWithLastScore.add(a1.node[i])) {
-                    merged.addInOrder(a1.node[i], a1.score[i]);
+                if (nodesWithLastScore.add(a1.nodes[i])) {
+                    merged.addInOrder(a1.nodes[i], a1.scores[i]);
                 }
-                if (nodesWithLastScore.add(a2.node[j])) {
-                    merged.addInOrder(a2.node[j], a2.score[j]);
+                if (nodesWithLastScore.add(a2.nodes[j])) {
+                    merged.addInOrder(a2.nodes[j], a2.scores[j]);
                 }
                 i++;
                 j++;
@@ -112,30 +112,30 @@ public class NodeArray {
         // If elements remain in a1, add them
         if (i < a1.size()) {
             // avoid duplicates while adding nodes with the same score
-            while (i < a1.size && a1.score[i] == lastAddedScore) {
-                if (!nodesWithLastScore.contains(a1.node[i])) {
-                    merged.addInOrder(a1.node[i], a1.score[i]);
+            while (i < a1.size && a1.scores[i] == lastAddedScore) {
+                if (!nodesWithLastScore.contains(a1.nodes[i])) {
+                    merged.addInOrder(a1.nodes[i], a1.scores[i]);
                 }
                 i++;
             }
             // the remaining nodes have a different score, so we can bulk-add them
-            System.arraycopy(a1.node, i, merged.node, merged.size, a1.size - i);
-            System.arraycopy(a1.score, i, merged.score, merged.size, a1.size - i);
+            System.arraycopy(a1.nodes, i, merged.nodes, merged.size, a1.size - i);
+            System.arraycopy(a1.scores, i, merged.scores, merged.size, a1.size - i);
             merged.size += a1.size - i;
         }
 
         // If elements remain in a2, add them
         if (j < a2.size()) {
             // avoid duplicates while adding nodes with the same score
-            while (j < a2.size && a2.score[j] == lastAddedScore) {
-                if (!nodesWithLastScore.contains(a2.node[j])) {
-                    merged.addInOrder(a2.node[j], a2.score[j]);
+            while (j < a2.size && a2.scores[j] == lastAddedScore) {
+                if (!nodesWithLastScore.contains(a2.nodes[j])) {
+                    merged.addInOrder(a2.nodes[j], a2.scores[j]);
                 }
                 j++;
             }
             // the remaining nodes have a different score, so we can bulk-add them
-            System.arraycopy(a2.node, j, merged.node, merged.size, a2.size - j);
-            System.arraycopy(a2.score, j, merged.score, merged.size, a2.size - j);
+            System.arraycopy(a2.nodes, j, merged.nodes, merged.size, a2.size - j);
+            System.arraycopy(a2.scores, j, merged.scores, merged.size, a2.size - j);
             merged.size += a2.size - j;
         }
 
@@ -147,19 +147,19 @@ public class NodeArray {
      * nodes.
      */
     public void addInOrder(int newNode, float newScore) {
-        if (size == node.length) {
+        if (size == nodes.length) {
             growArrays();
         }
         if (size > 0) {
-            float previousScore = score[size - 1];
+            float previousScore = scores[size - 1];
             assert ((previousScore >= newScore))
                     : "Nodes are added in the incorrect order! Comparing "
                     + newScore
                     + " to "
-                    + Arrays.toString(ArrayUtil.copyOfSubArray(score, 0, size));
+                    + Arrays.toString(ArrayUtil.copyOfSubArray(scores, 0, size));
         }
-        node[size] = newNode;
-        score[size] = newScore;
+        nodes[size] = newNode;
+        scores[size] = newScore;
         ++size;
     }
 
@@ -170,7 +170,7 @@ public class NodeArray {
      * @return the insertion point of the new node, or -1 if it already existed
      */
     public int insertSorted(int newNode, float newScore) {
-        if (size == node.length) {
+        if (size == nodes.length) {
             growArrays();
         }
         int insertionPoint = descSortFindRightMostInsertionPoint(newScore);
@@ -178,25 +178,25 @@ public class NodeArray {
             return -1;
         }
 
-        System.arraycopy(node, insertionPoint, node, insertionPoint + 1, size - insertionPoint);
-        System.arraycopy(score, insertionPoint, score, insertionPoint + 1, size - insertionPoint);
-        node[insertionPoint] = newNode;
-        score[insertionPoint] = newScore;
+        System.arraycopy(nodes, insertionPoint, nodes, insertionPoint + 1, size - insertionPoint);
+        System.arraycopy(scores, insertionPoint, scores, insertionPoint + 1, size - insertionPoint);
+        nodes[insertionPoint] = newNode;
+        scores[insertionPoint] = newScore;
         ++size;
         return insertionPoint;
     }
 
     private boolean duplicateExistsNear(int insertionPoint, int newNode, float newScore) {
         // Check to the left
-        for (int i = insertionPoint - 1; i >= 0 && score[i] == newScore; i--) {
-            if (node[i] == newNode) {
+        for (int i = insertionPoint - 1; i >= 0 && scores[i] == newScore; i--) {
+            if (nodes[i] == newNode) {
                 return true;
             }
         }
 
         // Check to the right
-        for (int i = insertionPoint; i < size && score[i] == newScore; i++) {
-            if (node[i] == newNode) {
+        for (int i = insertionPoint; i < size && scores[i] == newScore; i++) {
+            if (nodes[i] == newNode) {
                 return true;
             }
         }
@@ -221,8 +221,8 @@ public class NodeArray {
             if (selected.get(readIdx)) {
                 if (writeIdx != readIdx) {
                     // Move the selected entries to the front while maintaining their relative order
-                    node[writeIdx] = node[readIdx];
-                    score[writeIdx] = score[readIdx];
+                    nodes[writeIdx] = nodes[readIdx];
+                    scores[writeIdx] = scores[readIdx];
                 }
                 // else { we haven't created any gaps in the backing arrays yet, so we don't need to move anything }
                 writeIdx++;
@@ -243,14 +243,14 @@ public class NodeArray {
 
         NodeArray copy = new NodeArray(newSize);
         copy.size = size;
-        System.arraycopy(node, 0, copy.node, 0, size);
-        System.arraycopy(score, 0, copy.score, 0, size);
+        System.arraycopy(nodes, 0, copy.nodes, 0, size);
+        System.arraycopy(scores, 0, copy.scores, 0, size);
         return copy;
     }
 
     protected final void growArrays() {
-        node = ArrayUtil.grow(node);
-        score = ArrayUtil.growExact(score, node.length);
+        nodes = ArrayUtil.grow(nodes);
+        scores = ArrayUtil.growExact(scores, nodes.length);
     }
 
     public int size() {
@@ -266,17 +266,17 @@ public class NodeArray {
     }
 
     public void removeIndex(int idx) {
-        System.arraycopy(node, idx + 1, node, idx, size - idx - 1);
-        System.arraycopy(score, idx + 1, score, idx, size - idx - 1);
+        System.arraycopy(nodes, idx + 1, nodes, idx, size - idx - 1);
+        System.arraycopy(scores, idx + 1, scores, idx, size - idx - 1);
         size--;
     }
 
     @Override
     public String toString() {
         var sb = new StringBuilder("NodeArray(");
-        sb.append(size).append("/").append(node.length).append(") [");
+        sb.append(size).append("/").append(nodes.length).append(") [");
         for (int i = 0; i < size; i++) {
-            sb.append("(").append(node[i]).append(",").append(score[i]).append(")").append(", ");
+            sb.append("(").append(nodes[i]).append(",").append(scores[i]).append(")").append(", ");
         }
         sb.append("]");
         return sb.toString();
@@ -287,7 +287,7 @@ public class NodeArray {
         int end = size - 1;
         while (start <= end) {
             int mid = (start + end) / 2;
-            if (score[mid] < newScore) end = mid - 1;
+            if (scores[mid] < newScore) end = mid - 1;
             else start = mid + 1;
         }
         return start;
@@ -311,7 +311,7 @@ public class NodeArray {
     @VisibleForTesting
     boolean contains(int node) {
         for (int i = 0; i < size; i++) {
-            if (this.node[i] == node) {
+            if (this.nodes[i] == node) {
                 return true;
             }
         }
@@ -320,12 +320,12 @@ public class NodeArray {
 
     @VisibleForTesting
     int[] copyDenseNodes() {
-        return Arrays.copyOf(node, size);
+        return Arrays.copyOf(nodes, size);
     }
 
     @VisibleForTesting
     float[] copyDenseScores() {
-        return Arrays.copyOf(score, size);
+        return Arrays.copyOf(scores, size);
     }
 
     /**
@@ -333,19 +333,19 @@ public class NodeArray {
      * (Even if the worst existing one is better than newNode!)
      */
     protected int insertOrReplaceWorst(int newNode, float newScore) {
-        size = min(size, node.length - 1);
+        size = min(size, nodes.length - 1);
         return insertSorted(newNode, newScore);
     }
 
     public float getScore(int i) {
-        return score[i];
+        return scores[i];
     }
 
     public int getNode(int i) {
-        return node[i];
+        return nodes[i];
     }
 
     protected int getArrayLength() {
-        return node.length;
+        return nodes.length;
     }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeArray.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeArray.java
@@ -44,8 +44,8 @@ public class NodeArray {
     public static final NodeArray EMPTY = new NodeArray(0);
 
     private int size;
-    float[] score;
-    int[] node;
+    private float[] score;
+    private int[] node;
 
     public NodeArray(int initialSize) {
         node = new int[initialSize];
@@ -72,7 +72,7 @@ public class NodeArray {
         // loop through both source arrays, adding the highest score element to the merged array,
         // until we reach the end of one of the sources
         while (i < a1.size() && j < a2.size()) {
-            if (a1.score()[i] < a2.score[j]) {
+            if (a1.score[i] < a2.score[j]) {
                 // add from a2
                 if (a2.score[j] != lastAddedScore) {
                     nodesWithLastScore.clear();
@@ -82,26 +82,26 @@ public class NodeArray {
                     merged.addInOrder(a2.node[j], a2.score[j]);
                 }
                 j++;
-            } else if (a1.score()[i] > a2.score[j]) {
+            } else if (a1.score[i] > a2.score[j]) {
                 // add from a1
-                if (a1.score()[i] != lastAddedScore) {
+                if (a1.score[i] != lastAddedScore) {
                     nodesWithLastScore.clear();
-                    lastAddedScore = a1.score()[i];
+                    lastAddedScore = a1.score[i];
                 }
-                if (nodesWithLastScore.add(a1.node()[i])) {
-                    merged.addInOrder(a1.node()[i], a1.score()[i]);
+                if (nodesWithLastScore.add(a1.node[i])) {
+                    merged.addInOrder(a1.node[i], a1.score[i]);
                 }
                 i++;
             } else {
                 // same score -- add both
-                if (a1.score()[i] != lastAddedScore) {
+                if (a1.score[i] != lastAddedScore) {
                     nodesWithLastScore.clear();
-                    lastAddedScore = a1.score()[i];
+                    lastAddedScore = a1.score[i];
                 }
-                if (nodesWithLastScore.add(a1.node()[i])) {
-                    merged.addInOrder(a1.node()[i], a1.score()[i]);
+                if (nodesWithLastScore.add(a1.node[i])) {
+                    merged.addInOrder(a1.node[i], a1.score[i]);
                 }
-                if (nodesWithLastScore.add(a2.node()[j])) {
+                if (nodesWithLastScore.add(a2.node[j])) {
                     merged.addInOrder(a2.node[j], a2.score[j]);
                 }
                 i++;
@@ -112,9 +112,9 @@ public class NodeArray {
         // If elements remain in a1, add them
         if (i < a1.size()) {
             // avoid duplicates while adding nodes with the same score
-            while (i < a1.size && a1.score()[i] == lastAddedScore) {
-                if (!nodesWithLastScore.contains(a1.node()[i])) {
-                    merged.addInOrder(a1.node()[i], a1.score()[i]);
+            while (i < a1.size && a1.score[i] == lastAddedScore) {
+                if (!nodesWithLastScore.contains(a1.node[i])) {
+                    merged.addInOrder(a1.node[i], a1.score[i]);
                 }
                 i++;
             }
@@ -257,17 +257,6 @@ public class NodeArray {
         return size;
     }
 
-    /**
-     * Direct access to the internal list of node ids; provided for efficient writing of the graph
-     */
-    public int[] node() {
-        return node;
-    }
-
-    public float[] score() {
-        return score;
-    }
-
     public void clear() {
         size = 0;
     }
@@ -284,7 +273,13 @@ public class NodeArray {
 
     @Override
     public String toString() {
-        return "NodeArray[" + size + "]";
+        var sb = new StringBuilder("NodeArray(");
+        sb.append(size).append("/").append(node.length).append(") [");
+        for (int i = 0; i < size; i++) {
+            sb.append("(").append(node[i]).append(",").append(score[i]).append(")").append(", ");
+        }
+        sb.append("]");
+        return sb.toString();
     }
 
     protected final int descSortFindRightMostInsertionPoint(float newScore) {
@@ -328,6 +323,11 @@ public class NodeArray {
         return Arrays.copyOf(node, size);
     }
 
+    @VisibleForTesting
+    float[] copyDenseScores() {
+        return Arrays.copyOf(score, size);
+    }
+
     /**
      * Insert a new node, without growing the array.  If the array is full, drop the worst existing node to make room.
      * (Even if the worst existing one is better than newNode!)
@@ -335,5 +335,17 @@ public class NodeArray {
     protected int insertOrReplaceWorst(int newNode, float newScore) {
         size = min(size, node.length - 1);
         return insertSorted(newNode, newScore);
+    }
+
+    public float getScore(int i) {
+        return score[i];
+    }
+
+    public int getNode(int i) {
+        return node[i];
+    }
+
+    protected int getArrayLength() {
+        return node.length;
     }
 }

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestNodeArray.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestNodeArray.java
@@ -264,7 +264,7 @@ public class TestNodeArray extends RandomizedTest {
         } else {
           score = arr1.score[getRandom().nextInt(a1Size)];
         }
-        arr2.insertSorted(i + arr1.size, score);
+        arr2.insertSorted(i + arr1.size(), score);
       }
     }
 
@@ -272,16 +272,16 @@ public class TestNodeArray extends RandomizedTest {
     var merged = NodeArray.merge(arr1, arr2);
 
     // sanity check
-    assert merged.size <= arr1.size() + arr2.size();
-    assert merged.size >= Math.max(arr1.size(), arr2.size());
+    assert merged.size() <= arr1.size() + arr2.size();
+    assert merged.size() >= Math.max(arr1.size(), arr2.size());
     var uniqueNodes = new HashSet<>();
 
     // results should be sorted by score, and not contain duplicates
-    for (int i = 0; i < merged.size - 1; i++) {
+    for (int i = 0; i < merged.size() - 1; i++) {
       assertTrue(merged.score[i] >= merged.score[i + 1]);
       assertTrue(uniqueNodes.add(merged.node[i]));
     }
-    assertTrue(uniqueNodes.add(merged.node[merged.size - 1]));
+    assertTrue(uniqueNodes.add(merged.node[merged.size() - 1]));
 
     // results should contain all the nodes that were in the source arrays
     for (int i = 0; i < arr1.size(); i++) {


### PR DESCRIPTION
Goal is to make it easier to audit ConcurrentNeighborMap to make sure we're not mutating the edge lists without copying first.

Did not see any violations of this rule but did fix a minor bug with insertNotDiverse as part of the first (size-related) commit, see the new assert.

(Builds on top of the rerank PR.)