### PR TITLE
extract RandomAccessWriter interface from BRAW

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/RandomAccessWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/RandomAccessWriter.java
@@ -1,0 +1,18 @@
+package io.github.jbellis.jvector.disk;
+
+import java.io.Closeable;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/**
+ * A DataOutput that adds methods for random access writes
+ */
+public interface RandomAccessWriter extends DataOutput, Closeable {
+    void seek(long position) throws IOException;
+
+    long position() throws IOException;
+
+    void flush() throws IOException;
+
+    long checksum(long startOffset, long endOffset) throws IOException;
+}

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/RandomAccessWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/RandomAccessWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.github.jbellis.jvector.disk;
 
 import java.io.Closeable;

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/Header.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/Header.java
@@ -16,7 +16,6 @@
 
 package io.github.jbellis.jvector.graph.disk;
 
-import io.github.jbellis.jvector.disk.BufferedRandomAccessWriter;
 import io.github.jbellis.jvector.disk.RandomAccessReader;
 
 import java.io.DataOutput;

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
@@ -46,6 +46,7 @@ import io.github.jbellis.jvector.vector.types.VectorFloat;
 
 import java.io.BufferedOutputStream;
 import java.io.DataOutputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -232,7 +233,13 @@ public class Grid {
         return indexes;
     }
 
-    private static BuilderWithSuppliers builderWithSuppliers(Set<FeatureId> features, OnHeapGraphIndex onHeapGraph, Path outPath, RandomAccessVectorValues floatVectors, ProductQuantization pq) {
+    private static BuilderWithSuppliers builderWithSuppliers(Set<FeatureId> features,
+                                                             OnHeapGraphIndex onHeapGraph,
+                                                             Path outPath,
+                                                             RandomAccessVectorValues floatVectors,
+                                                             ProductQuantization pq)
+            throws FileNotFoundException
+    {
         var builder = new OnDiskGraphIndexWriter.Builder(onHeapGraph, outPath).withMapper(new OnDiskGraphIndexWriter.IdentityMapper());
         Map<FeatureId, IntFunction<Feature.State>> suppliers = new EnumMap<>(FeatureId.class);
         for (var featureId : features) {

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/IPCService.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/IPCService.java
@@ -16,7 +16,6 @@
 
 package io.github.jbellis.jvector.example;
 
-import io.github.jbellis.jvector.disk.BufferedRandomAccessWriter;
 import io.github.jbellis.jvector.example.util.MMapRandomAccessVectorValues;
 import io.github.jbellis.jvector.example.util.ReaderSupplierFactory;
 import io.github.jbellis.jvector.example.util.UpdatableRandomAccessVectorValues;


### PR DESCRIPTION
ODGIW.path is removed

commentary on path removal:

OnDiskGraphIndexWriter wanted to own a raw Path to create its writer from because back when we thought we needed to rerank from disk during LTM construction, we'd use the Path to create a per-thread RandomAccessFile backing a custom FeatureSource.

Since then I think we came up with a cleaner solution, which is to call ODGI.writeHeader, and then open up a normal ODGI and use its read methods.

Besides being cleaner, this has the advantage of making during-construction reads use the same well-optimized path as other reads instead of being a special snowflake.

Finally, if this is wrong and we do in fact find a need to open additional handles against the output file in ODGIW, we could add a getPath method to the RandomAccessWriter interface and we still wouldn't need to change the ODGIW api again.