### PR TITLE
Fixes for graphs with deletes

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
@@ -436,6 +436,11 @@ public class GraphIndexBuilder implements Closeable {
         }
     }
 
+    @VisibleForTesting
+    public void setEntryPoint(int ep) {
+        graph.updateEntryNode(ep);
+    }
+
     private void updateEntryPoint() {
         int newEntryNode = approximateMedioid();
         graph.updateEntryNode(newEntryNode);

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndexWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndexWriter.java
@@ -216,7 +216,11 @@ public class OnDiskGraphIndexWriter implements Closeable {
     public synchronized void writeHeader() throws IOException {
         // graph-level properties
         out.seek(startOffset);
-        var commonHeader = new CommonHeader(version, graph.size(), dimension, view.entryNode(), graph.maxDegree());
+        var commonHeader = new CommonHeader(version,
+                                            graph.size(),
+                                            dimension,
+                                            ordinalMapper.oldToNew(view.entryNode()),
+                                            graph.maxDegree());
         var header = new Header(commonHeader, featureMap);
         header.write(out);
         out.flush();

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndexWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndexWriter.java
@@ -317,55 +317,17 @@ public class OnDiskGraphIndexWriter implements Closeable {
             }
 
             if (ordinalMapper == null) {
-                ordinalMapper = new MapMapper(sequentialRenumbering(graphIndex));
+                ordinalMapper = new OrdinalMapper.MapMapper(sequentialRenumbering(graphIndex));
             }
             return new OnDiskGraphIndexWriter(out, version, startOffset, graphIndex, ordinalMapper, dimension, features);
         }
 
         public Builder withMap(Map<Integer, Integer> oldToNewOrdinals) {
-            return withMapper(new MapMapper(oldToNewOrdinals));
+            return withMapper(new OrdinalMapper.MapMapper(oldToNewOrdinals));
         }
 
         public Feature getFeature(FeatureId featureId) {
             return features.get(featureId);
-        }
-    }
-
-    public interface OrdinalMapper {
-        int oldToNew(int oldOrdinal);
-        int newToOld(int newOrdinal);
-    }
-
-    public static class IdentityMapper implements OrdinalMapper {
-        @Override
-        public int oldToNew(int oldOrdinal) {
-            return oldOrdinal;
-        }
-
-        @Override
-        public int newToOld(int newOrdinal) {
-            return newOrdinal;
-        }
-    }
-
-    private static class MapMapper implements OrdinalMapper {
-        private final Map<Integer, Integer> oldToNew;
-        private final int[] newToOld;
-
-        public MapMapper(Map<Integer, Integer> oldToNew) {
-            this.oldToNew = oldToNew;
-            this.newToOld = new int[oldToNew.size()];
-            oldToNew.forEach((old, newOrdinal) -> newToOld[newOrdinal] = old);
-        }
-
-        @Override
-        public int oldToNew(int oldOrdinal) {
-            return oldToNew.get(oldOrdinal);
-        }
-
-        @Override
-        public int newToOld(int newOrdinal) {
-            return newToOld[newOrdinal];
         }
     }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OrdinalMapper.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OrdinalMapper.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.graph.disk;
+
+import java.util.Map;
+
+public interface OrdinalMapper {
+    int oldToNew(int oldOrdinal);
+
+    int newToOld(int newOrdinal);
+
+    class IdentityMapper implements OrdinalMapper {
+        @Override
+        public int oldToNew(int oldOrdinal) {
+            return oldOrdinal;
+        }
+
+        @Override
+        public int newToOld(int newOrdinal) {
+            return newOrdinal;
+        }
+    }
+
+    class MapMapper implements OrdinalMapper {
+        private final Map<Integer, Integer> oldToNew;
+        private final int[] newToOld;
+
+        public MapMapper(Map<Integer, Integer> oldToNew) {
+            this.oldToNew = oldToNew;
+            this.newToOld = new int[oldToNew.size()];
+            oldToNew.forEach((old, newOrdinal) -> newToOld[newOrdinal] = old);
+        }
+
+        @Override
+        public int oldToNew(int oldOrdinal) {
+            return oldToNew.get(oldOrdinal);
+        }
+
+        @Override
+        public int newToOld(int newOrdinal) {
+            return newToOld[newOrdinal];
+        }
+    }
+}

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
@@ -32,6 +32,7 @@ import io.github.jbellis.jvector.graph.disk.FusedADC;
 import io.github.jbellis.jvector.graph.disk.InlineVectors;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndexWriter;
+import io.github.jbellis.jvector.graph.disk.OrdinalMapper;
 import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
 import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
@@ -240,7 +241,7 @@ public class Grid {
                                                              ProductQuantization pq)
             throws FileNotFoundException
     {
-        var builder = new OnDiskGraphIndexWriter.Builder(onHeapGraph, outPath).withMapper(new OnDiskGraphIndexWriter.IdentityMapper());
+        var builder = new OnDiskGraphIndexWriter.Builder(onHeapGraph, outPath).withMapper(new OrdinalMapper.IdentityMapper());
         Map<FeatureId, IntFunction<Feature.State>> suppliers = new EnumMap<>(FeatureId.class);
         for (var featureId : features) {
             switch (featureId) {

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
@@ -33,6 +33,7 @@ import io.github.jbellis.jvector.graph.disk.FeatureId;
 import io.github.jbellis.jvector.graph.disk.InlineVectors;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndexWriter;
+import io.github.jbellis.jvector.graph.disk.OrdinalMapper;
 import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction.ApproximateScoreFunction;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction.ExactScoreFunction;
@@ -225,7 +226,7 @@ public class SiftSmall {
              // explicit Writer for the first time, this is what's behind OnDiskGraphIndex.write
              OnDiskGraphIndexWriter writer = new OnDiskGraphIndexWriter.Builder(builder.getGraph(), indexPath)
                      .with(new InlineVectors(ravv.dimension()))
-                     .withMapper(new OnDiskGraphIndexWriter.IdentityMapper())
+                     .withMapper(new OrdinalMapper.IdentityMapper())
                      .build();
              // output for the compressed vectors
              DataOutputStream pqOut = new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(pqPath))))

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskGraphIndex.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskGraphIndex.java
@@ -92,6 +92,7 @@ public class TestOnDiskGraphIndex extends RandomizedTest {
         // delete the first node
         builder.markNodeDeleted(0);
         builder.cleanup();
+        builder.setEntryPoint(builder.getGraph().getIdUpperBound() - 1);
 
         // check
         assertEquals(2, original.size());
@@ -117,6 +118,8 @@ public class TestOnDiskGraphIndex extends RandomizedTest {
              var onDiskGraph = OnDiskGraphIndex.load(marr::duplicate);
              var onDiskView = onDiskGraph.getView())
         {
+            // entry point renumbering
+            assertNotNull(onDiskView.getVector(onDiskGraph.entryNode));
             // 0 -> 1
             assertTrue(getNeighborNodes(onDiskView, 0).contains(1));
             // 1 -> 0


### PR DESCRIPTION
for the entry point test, I don't love adding a public method that should only be used by tests, I did it because
1. We want the test to access package-private code from OnDiskGraphIndexWriter (disk subpackage)
2. And also package-private code from GraphIndexBuilder
3. But I don't want to move either class to a different package

I'm open to a better solution.