### PR TITLE
Use float in cosine metric final calculation in default vectorization provider

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/DefaultVectorUtilSupport.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/DefaultVectorUtilSupport.java
@@ -135,7 +135,7 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
       norm1 += elem1 * elem1;
       norm2 += elem2 * elem2;
     }
-    return (float) (sum / Math.sqrt((double) norm1 * (double) norm2));
+    return (float) (sum / Math.sqrt(norm1 * norm2));
   }
 
   @Override
@@ -152,7 +152,7 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
       norm1 += elem1 * elem1;
       norm2 += elem2 * elem2;
     }
-    return (float) (sum / Math.sqrt((double) norm1 * (double) norm2));
+    return (float) (sum / Math.sqrt(norm1 * norm2));
   }
 
   @Override


### PR DESCRIPTION
Makes the implementation consistent with Panama and native vectorization providers, which use float. Removes one of the sources of potentially different results for different providers.

Fixes https://github.com/jbellis/jvector/issues/357