### PR TITLE
Store compressed vectors in dense ByteSequence for PQVectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ Compressing the vectors with product quantization is done as follows:
                                                                  16, // number of subspaces
                                                                  256, // number of centroids per subspace
                                                                  true); // center the dataset
-            ByteSequence<?>[] compressed = pq.encodeAll(ravv);
+            // Note: before jvector 3.1.0, encodeAll returned an array of ByteSequence.
+            PQVectors pqv = pq.encodeAll(ravv);
             // write the compressed vectors to disk
-            PQVectors pqv = new PQVectors(pq, compressed);
             pqv.write(out);
         }
 ```

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,17 @@
+# Upgrading from 3.0.x to 3.1.x
+
+## Critical API changes
+
+- `VectorCompressor.encodeAll()` now returns a `CompressedVectors` object instead of a `ByteSequence<?>[]`.
+  This provides better encapsulation of the compression functionality while also allowing for more efficient
+  creation of the `CompressedVectors` object.
+- The `ByteSequence` interface now includes an `offset()` method to provide offset information for the sequence.
+  any time the method `ByteSequence::get` is called, the full backing data is returned, and as such, the `offset()`
+  method is necessary to determine the offset of the data in the backing array.
+- `PQVectors` constructor has been updated to support immutable instances and explicit chunking parameters.
+- The `VectorCompressor.createCompressedVectors(Object[])` method is now deprecated in favor of the new API that returns
+  `CompressedVectors` directly from `encodeAll()`.
+
 # Upgrading from 2.0.x to 3.0.x
 
 ## Critical API changes

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/BinaryQuantization.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/BinaryQuantization.java
@@ -63,12 +63,13 @@ public class BinaryQuantization implements VectorCompressor<long[]> {
     }
 
     @Override
-    public long[][] encodeAll(RandomAccessVectorValues ravv, ForkJoinPool simdExecutor) {
-        return simdExecutor.submit(() -> IntStream.range(0, ravv.size())
+    public CompressedVectors encodeAll(RandomAccessVectorValues ravv, ForkJoinPool simdExecutor) {
+        var cv = simdExecutor.submit(() -> IntStream.range(0, ravv.size())
                 .parallel()
                 .mapToObj(i -> encode(ravv.getVector(i)))
                 .toArray(long[][]::new))
                 .join();
+        return new BQVectors(this, cv);
     }
 
     /**

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/BinaryQuantization.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/BinaryQuantization.java
@@ -66,7 +66,12 @@ public class BinaryQuantization implements VectorCompressor<long[]> {
     public CompressedVectors encodeAll(RandomAccessVectorValues ravv, ForkJoinPool simdExecutor) {
         var cv = simdExecutor.submit(() -> IntStream.range(0, ravv.size())
                 .parallel()
-                .mapToObj(i -> encode(ravv.getVector(i)))
+                .mapToObj(i -> {
+                    var vector = ravv.getVector(i);
+                    return vector == null
+                            ? new long[compressedVectorSize() / Long.BYTES]
+                            : encode(vector);
+                })
                 .toArray(long[][]::new))
                 .join();
         return new BQVectors(this, cv);

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/BinaryQuantization.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/BinaryQuantization.java
@@ -81,7 +81,13 @@ public class BinaryQuantization implements VectorCompressor<long[]> {
     public long[] encode(VectorFloat<?> v) {
         int M = (int) Math.ceil(v.length() / 64.0);
         long[] encoded = new long[M];
-        for (int i = 0; i < M; i++) {
+        encodeTo(v, encoded);
+        return encoded;
+    }
+
+    @Override
+    public void encodeTo(VectorFloat<?> v, long[] dest) {
+        for (int i = 0; i < dest.length; i++) {
             long bits = 0;
             for (int j = 0; j < 64; j++) {
                 int idx = i * 64 + j;
@@ -92,9 +98,8 @@ public class BinaryQuantization implements VectorCompressor<long[]> {
                     bits |= 1L << j;
                 }
             }
-            encoded[i] = bits;
+            dest[i] = bits;
         }
-        return encoded;
     }
 
     @Override

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/PQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/PQVectors.java
@@ -256,6 +256,8 @@ public class PQVectors implements CompressedVectors {
     }
 
     public ByteSequence<?> get(int ordinal) {
+        if (ordinal < 0 || ordinal >= vectorCount)
+            throw new IndexOutOfBoundsException("Ordinal " + ordinal + " out of bounds for vector count " + vectorCount);
         return get(compressedDataChunks, ordinal, vectorsPerChunk, pq.getSubspaceCount());
     }
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/PQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/PQVectors.java
@@ -17,6 +17,7 @@
 package io.github.jbellis.jvector.pq;
 
 import io.github.jbellis.jvector.disk.RandomAccessReader;
+import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
 import io.github.jbellis.jvector.util.RamUsageEstimator;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
@@ -29,41 +30,58 @@ import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Objects;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
 
 public class PQVectors implements CompressedVectors {
     private static final VectorTypeSupport vectorTypeSupport = VectorizationProvider.getInstance().getVectorTypeSupport();
     static final int MAX_CHUNK_SIZE = Integer.MAX_VALUE - 16; // standard Java array size limit with some headroom
     final ProductQuantization pq;
     private final ByteSequence<?>[] compressedDataChunks;
-    private final int vectorCount;
+    private int vectorCount;
     private final int vectorsPerChunk;
     private final boolean mutable;
 
-    public PQVectors(ProductQuantization pq, int vectorCount)
+    /**
+     * Construct a PQVectors instance with the given ProductQuantization and maximum number of vectors that will be
+     * stored in this instance. The vectors are split into chunks to avoid exceeding the maximum array size.
+     * The instance is mutable and is not thread-safe.
+     * @param pq the ProductQuantization to use
+     * @param maximumVectorCount the maximum number of vectors that will be stored in this instance
+     */
+    public PQVectors(ProductQuantization pq, int maximumVectorCount)
     {
         this.pq = pq;
         this.mutable = true;
-        this.vectorCount = vectorCount;
+        this.vectorCount = 0;
 
         // Calculate if we need to split into multiple chunks
         int compressedDimension = pq.compressedVectorSize();
-        long totalSize = (long) vectorCount * compressedDimension;
-        this.vectorsPerChunk = totalSize <= MAX_CHUNK_SIZE ? vectorCount : MAX_CHUNK_SIZE / compressedDimension;
+        long totalSize = (long) maximumVectorCount * compressedDimension;
+        this.vectorsPerChunk = totalSize <= MAX_CHUNK_SIZE ? maximumVectorCount : MAX_CHUNK_SIZE / compressedDimension;
 
-        int numChunks = vectorCount / vectorsPerChunk;
+        int numChunks = maximumVectorCount / vectorsPerChunk;
         ByteSequence<?>[] chunks = new ByteSequence<?>[numChunks];
         int chunkSize = vectorsPerChunk * compressedDimension;
         for (int i = 0; i < numChunks - 1; i++)
             chunks[i] = vectorTypeSupport.createByteSequence(chunkSize);
 
         // Last chunk might be smaller
-        int remainingVectors = vectorCount - (vectorsPerChunk * (numChunks - 1));
+        int remainingVectors = maximumVectorCount - (vectorsPerChunk * (numChunks - 1));
         chunks[numChunks - 1] = vectorTypeSupport.createByteSequence(remainingVectors * compressedDimension);
 
         compressedDataChunks = chunks;
     }
 
+    /**
+     * Construct a PQVectors instance with the given ProductQuantization and compressed data chunks. The instance is
+     * immutable and thread-safe, though the underlying vectors may be mutable.
+     * @param pq the ProductQuantization to use
+     * @param compressedDataChunks the compressed data chunks
+     * @param vectorCount the number of vectors
+     * @param vectorsPerChunk the number of vectors per chunk
+     */
     public PQVectors(ProductQuantization pq, ByteSequence<?>[] compressedDataChunks, int vectorCount, int vectorsPerChunk)
     {
         this.pq = pq;
@@ -238,12 +256,14 @@ public class PQVectors implements CompressedVectors {
     }
 
     public ByteSequence<?> get(int ordinal) {
-        if (ordinal < 0 || ordinal >= vectorCount)
-            throw new IndexOutOfBoundsException("Ordinal " + ordinal + " out of bounds for vector count " + vectorCount);
+        return get(compressedDataChunks, ordinal, vectorsPerChunk, pq.getSubspaceCount());
+    }
+
+    private static ByteSequence<?> get(ByteSequence<?>[] chunks, int ordinal, int vectorsPerChunk, int subspaceCount) {
         int chunkIndex = ordinal / vectorsPerChunk;
         int vectorIndexInChunk = ordinal % vectorsPerChunk;
-        int start = vectorIndexInChunk * pq.getSubspaceCount();
-        return compressedDataChunks[chunkIndex].slice(start, pq.getSubspaceCount());
+        int start = vectorIndexInChunk * subspaceCount;
+        return chunks[chunkIndex].slice(start, subspaceCount);
     }
 
     /**
@@ -256,6 +276,7 @@ public class PQVectors implements CompressedVectors {
         if (!mutable)
             throw new UnsupportedOperationException("Cannot set values on an immutable PQVectors instance");
 
+        vectorCount++;
         pq.encodeTo(vector, get(ordinal));
     }
 
@@ -268,6 +289,7 @@ public class PQVectors implements CompressedVectors {
         if (!mutable)
             throw new UnsupportedOperationException("Cannot set values on an immutable PQVectors instance");
 
+        vectorCount++;
         get(ordinal).zero();
     }
 
@@ -319,5 +341,50 @@ public class PQVectors implements CompressedVectors {
                 "pq=" + pq +
                 ", count=" + vectorCount +
                 '}';
+    }
+
+    /**
+     * Build a PQVectors instance from the given RandomAccessVectorValues. The vectors are encoded in parallel
+     * and split into chunks to avoid exceeding the maximum array size.
+     * @param pq the ProductQuantization to use
+     * @param vectorCount the number of vectors to encode
+     * @param ravv the RandomAccessVectorValues to encode
+     * @param simdExecutor the ForkJoinPool to use for SIMD operations
+     * @return the PQVectors instance
+     */
+    public static PQVectors encodeAndBuild(ProductQuantization pq, int vectorCount, RandomAccessVectorValues ravv, ForkJoinPool simdExecutor) {
+
+        // Calculate if we need to split into multiple chunks
+        int compressedDimension = pq.compressedVectorSize();
+        long totalSize = (long) vectorCount * compressedDimension;
+        int vectorsPerChunk = totalSize <= MAX_CHUNK_SIZE ? vectorCount : MAX_CHUNK_SIZE / compressedDimension;
+
+        int numChunks = vectorCount / vectorsPerChunk;
+        final ByteSequence<?>[] chunks = new ByteSequence<?>[numChunks];
+        int chunkSize = vectorsPerChunk * compressedDimension;
+        for (int i = 0; i < numChunks - 1; i++)
+            chunks[i] = vectorTypeSupport.createByteSequence(chunkSize);
+
+        // Last chunk might be smaller
+        int remainingVectors = vectorCount - (vectorsPerChunk * (numChunks - 1));
+        chunks[numChunks - 1] = vectorTypeSupport.createByteSequence(remainingVectors * compressedDimension);
+
+        // Encode the vectors in parallel into the compressed data chunks
+        // The changes are concurrent, but because they are coordinated and do not overlap, we can use parallel streams
+        // and then we are guaranteed safe publication because we join the thread after completion.
+        simdExecutor.submit(() -> IntStream.range(0, ravv.size())
+                        .parallel()
+                        .forEach(ordinal -> {
+                            // Retrieve the slice and mutate it.
+                            var slice = get(chunks, ordinal, vectorsPerChunk, pq.getSubspaceCount());
+                            var vector = ravv.getVector(ordinal);
+                            if (vector != null)
+                                pq.encodeTo(vector, slice);
+                            else
+                                slice.zero();
+                        }))
+                .join();
+
+        return new PQVectors(pq, chunks, vectorCount, vectorsPerChunk);
     }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/PQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/PQVectors.java
@@ -238,6 +238,8 @@ public class PQVectors implements CompressedVectors {
     }
 
     public ByteSequence<?> get(int ordinal) {
+        if (ordinal < 0 || ordinal >= vectorCount)
+            throw new IndexOutOfBoundsException("Ordinal " + ordinal + " out of bounds for vector count " + vectorCount);
         int chunkIndex = ordinal / vectorsPerChunk;
         int vectorIndexInChunk = ordinal % vectorsPerChunk;
         int start = vectorIndexInChunk * pq.getSubspaceCount();
@@ -252,14 +254,21 @@ public class PQVectors implements CompressedVectors {
     public void encodeAndSet(int ordinal, VectorFloat<?> vector)
     {
         if (!mutable)
-        {
             throw new UnsupportedOperationException("Cannot set values on an immutable PQVectors instance");
-        }
-        int chunkIndex = ordinal / vectorsPerChunk;
-        int vectorIndexInChunk = ordinal % vectorsPerChunk;
-        int start = vectorIndexInChunk * pq.getSubspaceCount();
-        var slice = compressedDataChunks[chunkIndex].slice(start, pq.getSubspaceCount());
-        pq.encodeTo(vector, slice);
+
+        pq.encodeTo(vector, get(ordinal));
+    }
+
+    /**
+     * Set the vector at the given ordinal to zero.
+     * @param ordinal the ordinal to set
+     */
+    public void setZero(int ordinal)
+    {
+        if (!mutable)
+            throw new UnsupportedOperationException("Cannot set values on an immutable PQVectors instance");
+
+        get(ordinal).zero();
     }
 
     public ProductQuantization getProductQuantization() {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/PQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/PQVectors.java
@@ -145,28 +145,26 @@ public class PQVectors implements CompressedVectors {
         PQVectors that = (PQVectors) o;
         if (!Objects.equals(pq, that.pq)) return false;
         if (this.count() != that.count()) return false;
-        // TODO how do we want to determine equality? With the current change, we are willing to write one
-        // thing and materialize another. It seems like the real concern should be whether the compressedVectors have
-        // the same data, not whether they are in a MemorySegment or a byte[] and not whether there is one chunk of many
-        // vectors or many chunks of one vector. This technically goes against the implementation of each of the
-        // ByteSequence#equals methods, which raises the question of whether this is valid. I primarily updated this
-        // code to get testSaveLoadPQ to pass.
         for (int i = 0; i < this.count(); i++) {
             var thisNode = this.get(i);
             var thatNode = that.get(i);
-            if (thisNode.length() != thatNode.length()) return false;
-            for (int j = 0; j < thisNode.length(); j++) {
-                if (thisNode.get(j) != thatNode.get(j)) return false;
-            }
+            if (!thisNode.equals(thatNode)) return false;
         }
         return true;
     }
 
     @Override
     public int hashCode() {
+        int result = 1;
+        result = 31 * result + pq.hashCode();
+        result = 31 * result + count();
+
         // We don't use the array structure in the hash code calculation because we allow for different chunking
         // strategies. Instead, we use the first entry in the first chunk to provide a stable hash code.
-        return Objects.hash(pq, count(), count() > 0 ? get(0).get(0) : 0);
+        for (int i = 0; i < count(); i++)
+            result = 31 * result + get(i).hashCode();
+
+        return result;
     }
 
     @Override

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/PQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/PQVectors.java
@@ -246,7 +246,12 @@ public class PQVectors implements CompressedVectors {
         return compressedDataChunks[chunkIndex].slice(start, pq.getSubspaceCount());
     }
 
-    public void set(int ordinal, ByteSequence<?> byteSequence)
+    /**
+     * Encode the given vector and set it at the given ordinal. Done without unnecessary copying.
+     * @param ordinal the ordinal to set
+     * @param vector the vector to encode and set
+     */
+    public void encodeAndSet(int ordinal, VectorFloat<?> vector)
     {
         if (!mutable)
         {
@@ -255,8 +260,8 @@ public class PQVectors implements CompressedVectors {
         int chunkIndex = ordinal / vectorsPerChunk;
         int vectorIndexInChunk = ordinal % vectorsPerChunk;
         int start = vectorIndexInChunk * pq.getSubspaceCount();
-        assert byteSequence.length() == pq.getSubspaceCount() : "ByteSequence length mismatch " + byteSequence.length() + " != " + pq.getSubspaceCount();
-        compressedDataChunks[chunkIndex].copyFrom(byteSequence, 0, start, pq.getSubspaceCount());
+        var slice = compressedDataChunks[chunkIndex].slice(start, pq.getSubspaceCount());
+        pq.encodeTo(vector, slice);
     }
 
     public ProductQuantization getProductQuantization() {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/ProductQuantization.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/ProductQuantization.java
@@ -221,7 +221,7 @@ public class ProductQuantization implements VectorCompressor<ByteSequence<?>>, A
 
     @Override
     public CompressedVectors createCompressedVectors(Object[] compressedVectors) {
-        return new PQVectors(this, (ByteSequence<?>[]) compressedVectors);
+        return new PQVectors(this, (ByteSequence<?>[]) compressedVectors, compressedVectors.length, 1);
     }
 
     /**

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/ProductQuantization.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/ProductQuantization.java
@@ -230,18 +230,7 @@ public class ProductQuantization implements VectorCompressor<ByteSequence<?>>, A
      */
     @Override
     public PQVectors encodeAll(RandomAccessVectorValues ravv, ForkJoinPool simdExecutor) {
-        final PQVectors pqv = new PQVectors(this, ravv.size());
-        simdExecutor.submit(() -> IntStream.range(0, ravv.size())
-                .parallel()
-                .forEach(ordinal -> {
-                    var vector = ravv.getVector(ordinal);
-                    if (vector != null)
-                        pqv.encodeAndSet(ordinal, vector);
-                    else
-                        pqv.setZero(ordinal);
-                }))
-                .join();
-        return pqv;
+        return PQVectors.encodeAndBuild(this, ravv.size(), ravv, simdExecutor);
     }
 
     /**

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/ProductQuantization.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/ProductQuantization.java
@@ -228,12 +228,13 @@ public class ProductQuantization implements VectorCompressor<ByteSequence<?>>, A
      * Encodes the given vectors in parallel using the PQ codebooks.
      */
     @Override
-    public ByteSequence<?>[] encodeAll(RandomAccessVectorValues ravv, ForkJoinPool simdExecutor) {
-        return simdExecutor.submit(() -> IntStream.range(0, ravv.size())
-                        .parallel()
-                        .mapToObj(i -> encode(ravv.getVector(i)))
-                        .toArray(ByteSequence<?>[]::new))
+    public PQVectors encodeAll(RandomAccessVectorValues ravv, ForkJoinPool simdExecutor) {
+        final PQVectors pqv = new PQVectors(this, ravv.size());
+        simdExecutor.submit(() -> IntStream.range(0, ravv.size())
+                .parallel()
+                .forEach(ordinal -> pqv.set(ordinal, encode(ravv.getVector(ordinal)))))
                 .join();
+        return pqv;
     }
 
     /**

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/VectorCompressor.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/VectorCompressor.java
@@ -41,6 +41,8 @@ public interface VectorCompressor<T> {
 
     T encode(VectorFloat<?> v);
 
+    void encodeTo(VectorFloat<?> v, T dest);
+
     /**
      * @param out DataOutput to write to
      * @param version serialization version.  Versions 2 and 3 are supported

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/VectorCompressor.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/VectorCompressor.java
@@ -37,6 +37,13 @@ public interface VectorCompressor<T> {
         return encodeAll(ravv, PhysicalCoreExecutor.pool());
     }
 
+    /**
+     * Encode all vectors in the RandomAccessVectorValues. If the RandomAccessVectorValues
+     * has a missing vector for a given ordinal, the value will be encoded as a zero vector.
+     * @param ravv RandomAccessVectorValues to encode
+     * @param simdExecutor ForkJoinPool to use for SIMD operations
+     * @return CompressedVectors containing the encoded vectors
+     */
     CompressedVectors encodeAll(RandomAccessVectorValues ravv, ForkJoinPool simdExecutor);
 
     T encode(VectorFloat<?> v);

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/VectorCompressor.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/VectorCompressor.java
@@ -33,17 +33,11 @@ import java.util.concurrent.ForkJoinPool;
  */
 public interface VectorCompressor<T> {
 
-    default T[] encodeAll(RandomAccessVectorValues ravv) {
+    default CompressedVectors encodeAll(RandomAccessVectorValues ravv) {
         return encodeAll(ravv, PhysicalCoreExecutor.pool());
     }
 
-    @Deprecated
-    default T[] encodeAll(List<VectorFloat<?>> vectors) {
-        return encodeAll(new ListRandomAccessVectorValues(vectors, vectors.get(0).length()),
-                         PhysicalCoreExecutor.pool());
-    }
-
-    T[] encodeAll(RandomAccessVectorValues ravv, ForkJoinPool simdExecutor);
+    CompressedVectors encodeAll(RandomAccessVectorValues ravv, ForkJoinPool simdExecutor);
 
     T encode(VectorFloat<?> v);
 
@@ -63,6 +57,7 @@ public interface VectorCompressor<T> {
      *                          it is declared as Object because we want callers to be able to use this
      *                          without committing to a specific type T.
      */
+    @Deprecated
     CompressedVectors createCompressedVectors(Object[] compressedVectors);
 
     /** the size of the serialized compressor itself (NOT the size of compressed vectors) */

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArrayByteSequence.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArrayByteSequence.java
@@ -42,6 +42,11 @@ final public class ArrayByteSequence implements ByteSequence<byte[]>
     }
 
     @Override
+    public int offset() {
+        return 0;
+    }
+
+    @Override
     public byte get(int n) {
         return data[n];
     }
@@ -70,6 +75,14 @@ final public class ArrayByteSequence implements ByteSequence<byte[]>
     @Override
     public ArrayByteSequence copy() {
         return new ArrayByteSequence(Arrays.copyOf(data, data.length));
+    }
+
+    @Override
+    public ByteSequence<byte[]> slice(int offset, int length) {
+        if (offset == 0 && length == data.length) {
+            return this;
+        }
+        return new ArraySliceByteSequence(data, offset, length);
     }
 
     @Override

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArrayByteSequence.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArrayByteSequence.java
@@ -117,15 +117,12 @@ final public class ArrayByteSequence implements ByteSequence<byte[]>
     @Override
     public boolean equals(Object o)
     {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ArrayByteSequence that = (ArrayByteSequence) o;
-        return Arrays.equals(data, that.data);
+        return this.equalTo(o);
     }
 
     @Override
     public int hashCode()
     {
-        return Arrays.hashCode(data);
+        return this.getHashCode();
     }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArrayByteSequence.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArrayByteSequence.java
@@ -82,7 +82,7 @@ final public class ArrayByteSequence implements ByteSequence<byte[]>
         if (offset == 0 && length == data.length) {
             return this;
         }
-        return new ArraySliceByteSequence(data, offset, length);
+        return new ArraySliceByteSequence(this, offset, length);
     }
 
     @Override

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArraySliceByteSequence.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArraySliceByteSequence.java
@@ -131,22 +131,11 @@ public class ArraySliceByteSequence implements ByteSequence<byte[]> {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ArraySliceByteSequence that = (ArraySliceByteSequence) o;
-        if (this.length != that.length) return false;
-        for (int i = 0; i < length; i++) {
-            if (this.get(i) != that.get(i)) return false;
-        }
-        return true;
+        return this.equalTo(o);
     }
 
     @Override
     public int hashCode() {
-        int result = 1;
-        for (int i = 0; i < length; i++) {
-            result = 31 * result + get(i);
-        }
-        return result;
+        return this.getHashCode();
     }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArraySliceByteSequence.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArraySliceByteSequence.java
@@ -59,7 +59,10 @@ public class ArraySliceByteSequence implements ByteSequence<byte[]> {
 
     @Override
     public void setLittleEndianShort(int shortIndex, short value) {
-        data.setLittleEndianShort(offset + shortIndex, value);
+        // Can't call setLittleEndianShort because the method shifts the index and we don't require
+        // that the slice is aligned to a short boundary
+        data.set(offset + shortIndex * 2, (byte) (value & 0xFF));
+        data.set(offset + shortIndex * 2 + 1, (byte) ((value >> 8) & 0xFF));
     }
 
     @Override

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/types/ByteSequence.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/types/ByteSequence.java
@@ -17,6 +17,7 @@
 package io.github.jbellis.jvector.vector.types;
 
 import io.github.jbellis.jvector.util.Accountable;
+import java.util.Objects;
 
 public interface ByteSequence<T> extends Accountable
 {
@@ -46,4 +47,33 @@ public interface ByteSequence<T> extends Accountable
     ByteSequence<T> copy();
 
     ByteSequence<T>  slice(int offset, int length);
+
+    /**
+     * Two ByteSequences are equal if they have the same length and the same bytes at each position.
+     * @param o the other object to compare to
+     * @return true if the two ByteSequences are equal
+     */
+    default boolean equalTo(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ByteSequence)) return false;
+        ByteSequence<?> that = (ByteSequence<?>) o;
+        if (length() != that.length()) return false;
+        for (int i = 0; i < length(); i++) {
+            if (get(i) != that.get(i)) return false;
+        }
+        return true;
+    }
+
+    /**
+     * @return a hash code for this ByteSequence
+     */
+    default int getHashCode() {
+        int result = 1;
+        for (int i = 0; i < length(); i++) {
+            if (get(i) != 0) {
+                result = 31 * result + get(i);
+            }
+        }
+        return result;
+    }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/types/ByteSequence.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/types/ByteSequence.java
@@ -25,6 +25,8 @@ public interface ByteSequence<T> extends Accountable
      */
     T get();
 
+    int offset();
+
     int length();
 
     byte get(int i);
@@ -42,4 +44,6 @@ public interface ByteSequence<T> extends Accountable
     void copyFrom(ByteSequence<?> src, int srcOffset, int destOffset, int length);
 
     ByteSequence<T> copy();
+
+    ByteSequence<T>  slice(int offset, int length);
 }

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
@@ -125,8 +125,7 @@ public class Grid {
                     System.out.format("Uncompressed vectors%n");
                 } else {
                     long start = System.nanoTime();
-                    var quantizedVectors = compressor.encodeAll(ds.getBaseRavv());
-                    cv = compressor.createCompressedVectors(quantizedVectors);
+                    cv = compressor.encodeAll(ds.getBaseRavv());
                     System.out.format("%s encoded %d vectors [%.2f MB] in %.2fs%n", compressor, ds.baseVectors.size(), (cv.ramBytesUsed() / 1024f / 1024f), (System.nanoTime() - start) / 1_000_000_000.0);
                 }
 
@@ -159,8 +158,7 @@ public class Grid {
     {
         var floatVectors = ds.getBaseRavv();
 
-        var quantized = buildCompressor.encodeAll(floatVectors);
-        var pq = (PQVectors) buildCompressor.createCompressedVectors(quantized);
+        var pq = (PQVectors) buildCompressor.encodeAll(floatVectors);
         var bsp = BuildScoreProvider.pqBuildScoreProvider(ds.similarityFunction, pq);
         GraphIndexBuilder builder = new GraphIndexBuilder(bsp, floatVectors.dimension(), M, efConstruction, 1.5f, 1.2f);
 

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/IPCService.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/IPCService.java
@@ -182,17 +182,7 @@ public class IPCService
         ProductQuantization pq = ProductQuantization.compute(ravv, pqDims, 256, ctx.similarityFunction == VectorSimilarityFunction.EUCLIDEAN);
         System.out.format("PQ@%s build %.2fs,%n", pqDims, (System.nanoTime() - start) / 1_000_000_000.0);
         start = System.nanoTime();
-
-        ByteSequence<?>[] quantizedVectors = new ByteSequence<?>[ravv.size()];
-        var ravvCopy = ravv.threadLocalSupplier();
-        PhysicalCoreExecutor.instance.execute(() ->
-            IntStream.range(0, quantizedVectors.length).parallel().forEach(i -> {
-                var localRavv = ravvCopy.get();
-                quantizedVectors[i] = pq.encode(localRavv.getVector(i));
-            })
-        );
-
-        var cv = new PQVectors(pq, quantizedVectors);
+        var cv = pq.encodeAll(ravv);
         System.out.format("PQ encoded %d vectors [%.2f MB] in %.2fs,%n", ravv.size(), (cv.ramBytesUsed()/1024f/1024f) , (System.nanoTime() - start) / 1_000_000_000.0);
         return cv;
     }

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
@@ -215,8 +215,8 @@ public class SiftSmall {
 
         // as we build the index we'll compress the new vectors and add them to this List backing a PQVectors;
         // this is used to score the construction searches
-        List<ByteSequence<?>> incrementallyCompressedVectors = new ArrayList<>();
-        PQVectors pqv = new PQVectors(pq, incrementallyCompressedVectors);
+        ByteSequence<?>[] incrementallyCompressedVectors = new ByteSequence[baseVectors.size() * pq.compressedVectorSize()];
+        PQVectors pqv = new PQVectors(pq, incrementallyCompressedVectors, baseVectors.size(), 1);
         BuildScoreProvider bsp = BuildScoreProvider.pqBuildScoreProvider(VectorSimilarityFunction.EUCLIDEAN, pqv);
 
         Path indexPath = Files.createTempFile("siftsmall", ".inline");
@@ -232,10 +232,10 @@ public class SiftSmall {
              DataOutputStream pqOut = new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(pqPath))))
         {
             // build the index vector-at-a-time (on disk)
-            for (VectorFloat<?> v : baseVectors) {
+            for (int ordinal = 0; ordinal < baseVectors.size(); ordinal++) {
+                VectorFloat<?> v = baseVectors.get(ordinal);
                 // compress the new vector and add it to the PQVectors (via incrementallyCompressedVectors)
-                int ordinal = incrementallyCompressedVectors.size();
-                incrementallyCompressedVectors.add(pq.encode(v));
+                incrementallyCompressedVectors[ordinal] = pq.encode(v);
                 // write the full vector to disk
                 writer.writeInline(ordinal, Feature.singleState(FeatureId.INLINE_VECTORS, new InlineVectors.State(v)));
                 // now add it to the graph -- the previous steps must be completed first since the PQVectors

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
@@ -46,7 +46,6 @@ import io.github.jbellis.jvector.util.ExplicitThreadLocal;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorUtil;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
-import io.github.jbellis.jvector.vector.types.ByteSequence;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 
@@ -233,7 +232,7 @@ public class SiftSmall {
             for (int ordinal = 0; ordinal < baseVectors.size(); ordinal++) {
                 VectorFloat<?> v = baseVectors.get(ordinal);
                 // compress the new vector and add it to the PQVectors (via incrementallyCompressedVectors)
-                pqv.set(ordinal, pq.encode(v));
+                pqv.encodeAndSet(ordinal, v);
                 // write the full vector to disk
                 writer.writeInline(ordinal, Feature.singleState(FeatureId.INLINE_VECTORS, new InlineVectors.State(v)));
                 // now add it to the graph -- the previous steps must be completed first since the PQVectors

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/MemorySegmentByteSequence.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/MemorySegmentByteSequence.java
@@ -133,14 +133,11 @@ public class MemorySegmentByteSequence implements ByteSequence<MemorySegment> {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        MemorySegmentByteSequence that = (MemorySegmentByteSequence) o;
-        return segment.mismatch(that.segment) == -1;
+        return this.equalTo(o);
     }
 
     @Override
     public int hashCode() {
-        return segment.hashCode();
+        return this.getHashCode();
     }
 }

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/MemorySegmentByteSequence.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/MemorySegmentByteSequence.java
@@ -49,6 +49,11 @@ public class MemorySegmentByteSequence implements ByteSequence<MemorySegment> {
         this.length = data.length;
     }
 
+    private MemorySegmentByteSequence(MemorySegment segment) {
+        this.segment = segment;
+        this.length = Math.toIntExact(segment.byteSize());
+    }
+
     @Override
     public long ramBytesUsed() {
         int OH_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_HEADER;
@@ -65,6 +70,11 @@ public class MemorySegmentByteSequence implements ByteSequence<MemorySegment> {
     @Override
     public MemorySegment get() {
         return segment;
+    }
+
+    @Override
+    public int offset() {
+        return 0;
     }
 
     @Override
@@ -97,6 +107,11 @@ public class MemorySegmentByteSequence implements ByteSequence<MemorySegment> {
         MemorySegmentByteSequence copy = new MemorySegmentByteSequence(length());
         copy.copyFrom(this, 0, 0, length());
         return copy;
+    }
+
+    @Override
+    public MemorySegmentByteSequence slice(int offset, int length) {
+        return new MemorySegmentByteSequence(segment.asSlice(offset, length));
     }
 
     @Override

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/NativeVectorUtilSupport.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/NativeVectorUtilSupport.java
@@ -97,6 +97,7 @@ final class NativeVectorUtilSupport implements VectorUtilSupport
 
     @Override
     public float assembleAndSum(VectorFloat<?> data, int dataBase, ByteSequence<?> baseOffsets) {
+        assert baseOffsets.offset() == 0 : "Base offsets are expected to have an offset of 0. Found: " + baseOffsets.offset();
         return NativeSimdOps.assemble_and_sum_f32_512(((MemorySegmentVectorFloat)data).get(), dataBase, ((MemorySegmentByteSequence)baseOffsets).get(), baseOffsets.length());
     }
 
@@ -140,6 +141,7 @@ final class NativeVectorUtilSupport implements VectorUtilSupport
 
     @Override
     public void bulkShuffleQuantizedSimilarity(ByteSequence<?> shuffles, int codebookCount, ByteSequence<?> quantizedPartials, float delta, float bestDistance, VectorSimilarityFunction vsf, VectorFloat<?> results) {
+        assert shuffles.offset() == 0 : "Bulk shuffle shuffles are expected to have an offset of 0. Found: " + shuffles.offset();
         switch (vsf) {
             case DOT_PRODUCT -> NativeSimdOps.bulk_quantized_shuffle_dot_f32_512(((MemorySegmentByteSequence) shuffles).get(), codebookCount, ((MemorySegmentByteSequence) quantizedPartials).get(), delta, bestDistance, ((MemorySegmentVectorFloat) results).get());
             case EUCLIDEAN -> NativeSimdOps.bulk_quantized_shuffle_euclidean_f32_512(((MemorySegmentByteSequence) shuffles).get(), codebookCount, ((MemorySegmentByteSequence) quantizedPartials).get(), delta, bestDistance, ((MemorySegmentVectorFloat) results).get());
@@ -152,6 +154,7 @@ final class NativeVectorUtilSupport implements VectorUtilSupport
                                                      ByteSequence<?> quantizedPartialSums, float sumDelta, float minDistance,
                                                      ByteSequence<?> quantizedPartialSquaredMagnitudes, float magnitudeDelta, float minMagnitude,
                                                      float queryMagnitudeSquared, VectorFloat<?> results) {
+        assert shuffles.offset() == 0 : "Bulk shuffle shuffles are expected to have an offset of 0. Found: " + shuffles.offset();
         NativeSimdOps.bulk_quantized_shuffle_cosine_f32_512(((MemorySegmentByteSequence) shuffles).get(), codebookCount, ((MemorySegmentByteSequence) quantizedPartialSums).get(), sumDelta, minDistance,
                 ((MemorySegmentByteSequence) quantizedPartialSquaredMagnitudes).get(), magnitudeDelta, minMagnitude, queryMagnitudeSquared, ((MemorySegmentVectorFloat) results).get());
     }
@@ -159,6 +162,7 @@ final class NativeVectorUtilSupport implements VectorUtilSupport
     @Override
     public float pqDecodedCosineSimilarity(ByteSequence<?> encoded, int clusterCount, VectorFloat<?> partialSums, VectorFloat<?> aMagnitude, float bMagnitude)
     {
+        assert encoded.offset() == 0 : "Bulk shuffle shuffles are expected to have an offset of 0. Found: " + encoded.offset();
         return NativeSimdOps.pq_decoded_cosine_similarity_f32_512(((MemorySegmentByteSequence) encoded).get(), encoded.length(), clusterCount, ((MemorySegmentVectorFloat) partialSums).get(), ((MemorySegmentVectorFloat) aMagnitude).get(), bMagnitude);
     }
 }

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestVectorGraph.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestVectorGraph.java
@@ -167,8 +167,7 @@ public class TestVectorGraph extends LuceneTestCase {
         var graph = builder.build(vectors);
 
         var pq = ProductQuantization.compute(vectors, 2, 256, false);
-        var encoded = pq.encodeAll(vectors);
-        var pqv = new PQVectors(pq, encoded);
+        var pqv = pq.encodeAll(vectors);
 
         int topK = 10;
         int rerankK = 30;

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskGraphIndex.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskGraphIndex.java
@@ -323,7 +323,7 @@ public class TestOnDiskGraphIndex extends RandomizedTest {
         // write incrementally and add Fused ADC Feature
         var incrementalFadcPath = testDirectory.resolve("incremental_graph");
         var pq = ProductQuantization.compute(ravv, 64, 256, false);
-        var pqv = (PQVectors) pq.createCompressedVectors(pq.encodeAll(ravv));
+        var pqv = (PQVectors) pq.encodeAll(ravv);
         try (var writer = new OnDiskGraphIndexWriter.Builder(graph, incrementalFadcPath)
                 .with(new InlineVectors(ravv.dimension()))
                 .with(new FusedADC(graph.maxDegree(), pq))

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/pq/TestADCGraphIndex.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/pq/TestADCGraphIndex.java
@@ -58,8 +58,7 @@ public class TestADCGraphIndex extends RandomizedTest {
         var vectors = createRandomVectors(1000,  512);
         var ravv = new ListRandomAccessVectorValues(vectors, 512);
         var pq = ProductQuantization.compute(ravv, 8, 256, false);
-        var compressed = pq.encodeAll(ravv);
-        var pqv = new PQVectors(pq, compressed);
+        var pqv = (PQVectors) pq.encodeAll(ravv);
 
         TestUtil.writeFusedGraph(graph, ravv, pqv, outputPath);
 

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/pq/TestCompressedVectors.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/pq/TestCompressedVectors.java
@@ -59,6 +59,7 @@ public class TestCompressedVectors extends RandomizedTest {
         // Read compressed vectors
         try (var in = new SimpleMappedReader(cvFile.getAbsolutePath())) {
             var cv2 = PQVectors.load(in, 0);
+            assertEquals(cv.hashCode(), cv2.hashCode());
             assertEquals(cv, cv2);
         }
     }

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/pq/TestCompressedVectors.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/pq/TestCompressedVectors.java
@@ -46,8 +46,7 @@ public class TestCompressedVectors extends RandomizedTest {
         var pq = ProductQuantization.compute(ravv, 1, 256, false);
 
         // Compress the vectors
-        var compressed = pq.encodeAll(ravv);
-        var cv = new PQVectors(pq, compressed);
+        var cv = pq.encodeAll(ravv);
         assertEquals(2 * Float.BYTES, cv.getOriginalSize());
         assertEquals(1, cv.getCompressedSize());
 
@@ -72,8 +71,7 @@ public class TestCompressedVectors extends RandomizedTest {
         var bq = new BinaryQuantization(ravv.dimension());
 
         // Compress the vectors
-        var compressed = bq.encodeAll(ravv);
-        var cv = new BQVectors(bq, compressed);
+        var cv = bq.encodeAll(ravv);
         assertEquals(64 * Float.BYTES, cv.getOriginalSize());
         assertEquals(8, cv.getCompressedSize());
 
@@ -96,8 +94,7 @@ public class TestCompressedVectors extends RandomizedTest {
         var pq = ProductQuantization.compute(ravv, codebooks, 256, false);
 
         // Compress the vectors
-        var compressed = pq.encodeAll(ravv);
-        var cv = new PQVectors(pq, compressed);
+        var cv = pq.encodeAll(ravv);
 
         // compare the encoded similarities to the raw
         for (var vsf : List.of(VectorSimilarityFunction.EUCLIDEAN, VectorSimilarityFunction.DOT_PRODUCT, VectorSimilarityFunction.COSINE)) {
@@ -141,8 +138,7 @@ public class TestCompressedVectors extends RandomizedTest {
             var pq = ProductQuantization.compute(ravv, codebooks, 256, center);
 
             // Compress the vectors
-            var compressed = pq.encodeAll(ravv);
-            var cv = new PQVectors(pq, compressed);
+            var cv = pq.encodeAll(ravv);
 
             // compare the precomputed similarities to the raw
             for (int i = 0; i < 10; i++) {

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/pq/TestProductQuantization.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/pq/TestProductQuantization.java
@@ -73,10 +73,10 @@ public class TestProductQuantization extends RandomizedTest {
     private static void assertPerfectQuantization(List<VectorFloat<?>> vectors) {
         var ravv = new ListRandomAccessVectorValues(vectors, 3);
         var pq = ProductQuantization.compute(ravv, 2, DEFAULT_CLUSTERS, false);
-        var encoded = pq.encodeAll(ravv);
+        var cv = (PQVectors) pq.encodeAll(ravv);
         var decodedScratch = vectorTypeSupport.createFloatVector(3);
         for (int i = 0; i < vectors.size(); i++) {
-            pq.decode(encoded[i], decodedScratch);
+            pq.decode(cv.get(i), decodedScratch);
             assertEquals(vectors.get(i), decodedScratch);
         }
     }
@@ -168,11 +168,11 @@ public class TestProductQuantization extends RandomizedTest {
                                          null,
                                          UNWEIGHTED);
         var ravv = new ListRandomAccessVectorValues(List.of(vectors), vectors[0].length());
-        var encoded = pq.encodeAll(ravv);
+        var cv = (PQVectors) pq.encodeAll(ravv);
         var loss = 0.0;
         var decodedScratch = vectorTypeSupport.createFloatVector(vectors[0].length());
         for (int i = 0; i < vectors.length; i++) {
-            pq.decode(encoded[i], decodedScratch);
+            pq.decode(cv.get(i), decodedScratch);
             if (VectorUtil.dotProduct(vectors[i], decodedScratch) >= T) {
                 loss += 1 - VectorSimilarityFunction.EUCLIDEAN.compare(vectors[i], decodedScratch);
             }

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/vector/TestArraySliceByteSequence.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/vector/TestArraySliceByteSequence.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jbellis.jvector.vector;
+
+import io.github.jbellis.jvector.vector.types.ByteSequence;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class TestArraySliceByteSequence {
+
+    @Test
+    void testConstructorValidation() {
+        byte[] data = {1, 2, 3, 4, 5};
+        ByteSequence<byte[]> baseSequence = new ArrayByteSequence(data);
+
+        // Valid construction
+        assertDoesNotThrow(() -> new ArraySliceByteSequence(baseSequence, 0, 5));
+        assertDoesNotThrow(() -> new ArraySliceByteSequence(baseSequence, 1, 3));
+
+        // Invalid constructions
+        assertThrows(IllegalArgumentException.class, () -> new ArraySliceByteSequence(baseSequence, -1, 3));
+        assertThrows(IllegalArgumentException.class, () -> new ArraySliceByteSequence(baseSequence, 0, -1));
+        assertThrows(IllegalArgumentException.class, () -> new ArraySliceByteSequence(baseSequence, 0, 6));
+        assertThrows(IllegalArgumentException.class, () -> new ArraySliceByteSequence(baseSequence, 4, 2));
+    }
+
+    @Test
+    void testBasicOperations() {
+        byte[] data = {1, 2, 3, 4, 5};
+        ByteSequence<byte[]> baseSequence = new ArrayByteSequence(data);
+        ArraySliceByteSequence slice = new ArraySliceByteSequence(baseSequence, 1, 3);
+
+        // Test get()
+        assertArrayEquals(data, slice.get());
+
+        // Test offset()
+        assertEquals(1, slice.offset());
+
+        // Test length()
+        assertEquals(3, slice.length());
+
+        // Test get(n)
+        assertEquals(2, slice.get(0));
+        assertEquals(3, slice.get(1));
+        assertEquals(4, slice.get(2));
+    }
+
+    @Test
+    void testSetOperations() {
+        byte[] data = {1, 2, 3, 4, 5};
+        ByteSequence<byte[]> baseSequence = new ArrayByteSequence(data);
+        ArraySliceByteSequence slice = new ArraySliceByteSequence(baseSequence, 1, 3);
+
+        // Test set(n, value)
+        slice.set(0, (byte) 10);
+        assertEquals(10, slice.get(0));
+        assertEquals(10, baseSequence.get(1));
+
+        // Test setLittleEndianShort
+        slice.setLittleEndianShort(0, (short) 258); // 258 = 0x0102
+        assertEquals(2, slice.get(0));  // least significant byte
+        assertEquals(1, slice.get(1));  // most significant byte
+    }
+
+    @Test
+    void testZero() {
+        byte[] data = {1, 2, 3, 4, 5};
+        ByteSequence<byte[]> baseSequence = new ArrayByteSequence(data);
+        ArraySliceByteSequence slice = new ArraySliceByteSequence(baseSequence, 1, 3);
+
+        slice.zero();
+        assertEquals(0, slice.get(0));
+        assertEquals(0, slice.get(1));
+        assertEquals(0, slice.get(2));
+        assertEquals(1, baseSequence.get(0)); // Verify surrounding data unchanged
+        assertEquals(5, baseSequence.get(4));
+    }
+
+    @Test
+    void testCopy() {
+        byte[] data = {1, 2, 3, 4, 5};
+        ByteSequence<byte[]> baseSequence = new ArrayByteSequence(data);
+        ArraySliceByteSequence slice = new ArraySliceByteSequence(baseSequence, 1, 3);
+
+        ByteSequence<byte[]> copy = slice.copy();
+        assertEquals(3, copy.length());
+        assertEquals(2, copy.get(0));
+        assertEquals(3, copy.get(1));
+        assertEquals(4, copy.get(2));
+    }
+
+    @Test
+    void testSlice() {
+        byte[] data = {1, 2, 3, 4, 5};
+        ByteSequence<byte[]> baseSequence = new ArrayByteSequence(data);
+        ArraySliceByteSequence slice = new ArraySliceByteSequence(baseSequence, 1, 3);
+
+        // Test valid slices
+        ByteSequence<byte[]> subSlice = slice.slice(1, 2);
+        assertEquals(2, subSlice.length());
+        assertEquals(3, subSlice.get(0));
+        assertEquals(4, subSlice.get(1));
+
+        // Test invalid slices
+        assertThrows(IllegalArgumentException.class, () -> slice.slice(-1, 2));
+        assertThrows(IllegalArgumentException.class, () -> slice.slice(0, 4));
+
+        // Test full slice returns same instance
+        assertSame(slice, slice.slice(0, slice.length()));
+    }
+
+    @Test
+    void testCopyFrom() {
+        byte[] sourceData = {10, 11, 12, 13, 14};
+        byte[] destData = {1, 2, 3, 4, 5};
+        ByteSequence<byte[]> sourceSeq = new ArrayByteSequence(sourceData);
+        ByteSequence<byte[]> destSeq = new ArrayByteSequence(destData);
+
+        ArraySliceByteSequence destSlice = new ArraySliceByteSequence(destSeq, 1, 3);
+
+        // Test copying from another ArraySliceByteSequence
+        ArraySliceByteSequence sourceSlice = new ArraySliceByteSequence(sourceSeq, 1, 3);
+        destSlice.copyFrom(sourceSlice, 0, 0, 2);
+        assertEquals(11, destSlice.get(0));
+        assertEquals(12, destSlice.get(1));
+
+        // Test copying from a regular ByteSequence
+        destSlice.copyFrom(sourceSeq, 0, 1, 2);
+        assertEquals(10, destSlice.get(1));
+        assertEquals(11, destSlice.get(2));
+    }
+
+    @Test
+    void testToString() {
+        byte[] data = new byte[30];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) i;
+        }
+        ByteSequence<byte[]> baseSequence = new ArrayByteSequence(data);
+        ArraySliceByteSequence slice = new ArraySliceByteSequence(baseSequence, 0, 30);
+
+        String result = slice.toString();
+        assertTrue(result.startsWith("[0, 1, 2"));
+        assertTrue(result.endsWith("...]"));
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        byte[] data1 = {1, 2, 3, 4, 5};
+        byte[] data2 = {1, 2, 3, 4, 5};
+        byte[] data3 = {1, 2, 3, 4, 6};
+
+        ByteSequence<byte[]> seq1 = new ArrayByteSequence(data1);
+        ByteSequence<byte[]> seq2 = new ArrayByteSequence(data2);
+        ByteSequence<byte[]> seq3 = new ArrayByteSequence(data3);
+
+        ArraySliceByteSequence slice1 = new ArraySliceByteSequence(seq1, 2, 3);
+        ArraySliceByteSequence slice2 = new ArraySliceByteSequence(seq2, 2, 3);
+        ArraySliceByteSequence slice3 = new ArraySliceByteSequence(seq3, 2, 3);
+
+        // Test equals
+        assertEquals(slice1, slice2);
+        assertNotEquals(slice1, slice3);
+
+        // Test hashCode
+        assertEquals(slice1.hashCode(), slice2.hashCode());
+        assertNotEquals(slice1.hashCode(), slice3.hashCode());
+    }
+}

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorUtilSupport.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorUtilSupport.java
@@ -92,7 +92,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
     @Override
     public float assembleAndSum(VectorFloat<?> data, int dataBase, ByteSequence<?> baseOffsets) {
-        return SimdOps.assembleAndSum(((ArrayVectorFloat) data).get(), dataBase, ((ArrayByteSequence) baseOffsets).get());
+        return SimdOps.assembleAndSum(((ArrayVectorFloat) data).get(), dataBase, ((ByteSequence<byte[]>) baseOffsets));
     }
 
     @Override

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorUtilSupport.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorUtilSupport.java
@@ -159,7 +159,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     @Override
     public float pqDecodedCosineSimilarity(ByteSequence<?> encoded, int clusterCount, VectorFloat<?> partialSums, VectorFloat<?> aMagnitude, float bMagnitude)
     {
-        return SimdOps.pqDecodedCosineSimilarity((ArrayByteSequence) encoded, clusterCount, (ArrayVectorFloat) partialSums, (ArrayVectorFloat) aMagnitude, bMagnitude);
+        return SimdOps.pqDecodedCosineSimilarity((ByteSequence<byte[]>) encoded, clusterCount, (ArrayVectorFloat) partialSums, (ArrayVectorFloat) aMagnitude, bMagnitude);
     }
 }
 

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
@@ -516,20 +516,20 @@ final class SimdOps {
         return new ArrayVectorFloat(res);
     }
 
-    static float assembleAndSum(float[] data, int dataBase, byte[] baseOffsets) {
+    static float assembleAndSum(float[] data, int dataBase, ByteSequence<byte[]> baseOffsets) {
         return HAS_AVX512 ? assembleAndSum512(data, dataBase, baseOffsets)
                : assembleAndSum256(data, dataBase, baseOffsets);
     }
 
-    static float assembleAndSum512(float[] data, int dataBase, byte[] baseOffsets) {
+    static float assembleAndSum512(float[] data, int dataBase, ByteSequence<byte[]> baseOffsets) {
         int[] convOffsets = scratchInt512.get();
         FloatVector sum = FloatVector.zero(FloatVector.SPECIES_512);
         int i = 0;
-        int limit = ByteVector.SPECIES_128.loopBound(baseOffsets.length);
+        int limit = ByteVector.SPECIES_128.loopBound(baseOffsets.length());
         var scale = IntVector.zero(IntVector.SPECIES_512).addIndex(dataBase);
 
         for (; i < limit; i += ByteVector.SPECIES_128.length()) {
-            ByteVector.fromArray(ByteVector.SPECIES_128, baseOffsets, i)
+            ByteVector.fromArray(ByteVector.SPECIES_128, baseOffsets.get(), i + baseOffsets.offset())
                     .convertShape(VectorOperators.B2I, IntVector.SPECIES_512, 0)
                     .lanewise(VectorOperators.AND, BYTE_TO_INT_MASK_512)
                     .reinterpretAsInts()
@@ -543,22 +543,22 @@ final class SimdOps {
         float res = sum.reduceLanes(VectorOperators.ADD);
 
         //Process tail
-        for (; i < baseOffsets.length; i++)
-            res += data[dataBase * i + Byte.toUnsignedInt(baseOffsets[i])];
+        for (; i < baseOffsets.length(); i++)
+            res += data[dataBase * i + Byte.toUnsignedInt(baseOffsets.get(i))];
 
         return res;
     }
 
-    static float assembleAndSum256(float[] data, int dataBase, byte[] baseOffsets) {
+    static float assembleAndSum256(float[] data, int dataBase, ByteSequence<byte[]> baseOffsets) {
         int[] convOffsets = scratchInt256.get();
         FloatVector sum = FloatVector.zero(FloatVector.SPECIES_256);
         int i = 0;
-        int limit = ByteVector.SPECIES_64.loopBound(baseOffsets.length);
+        int limit = ByteVector.SPECIES_64.loopBound(baseOffsets.length());
         var scale = IntVector.zero(IntVector.SPECIES_256).addIndex(dataBase);
 
         for (; i < limit; i += ByteVector.SPECIES_64.length()) {
 
-            ByteVector.fromArray(ByteVector.SPECIES_64, baseOffsets, i)
+            ByteVector.fromArray(ByteVector.SPECIES_64, baseOffsets.get(), i + baseOffsets.offset())
                     .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0)
                     .lanewise(VectorOperators.AND, BYTE_TO_INT_MASK_256)
                     .reinterpretAsInts()
@@ -572,8 +572,8 @@ final class SimdOps {
         float res = sum.reduceLanes(VectorOperators.ADD);
 
         // Process tail
-        for (; i < baseOffsets.length; i++)
-            res += data[dataBase * i + Byte.toUnsignedInt(baseOffsets[i])];
+        for (; i < baseOffsets.length(); i++)
+            res += data[dataBase * i + Byte.toUnsignedInt(baseOffsets.get(i))];
 
         return res;
     }
@@ -667,23 +667,21 @@ final class SimdOps {
                 : pqDecodedCosineSimilarity256(encoded, clusterCount, partialSums, aMagnitude, bMagnitude);
     }
 
-    public static float pqDecodedCosineSimilarity512(ByteSequence<byte[]> encoded, int clusterCount, ArrayVectorFloat partialSums, ArrayVectorFloat aMagnitude, float bMagnitude) {
+    public static float pqDecodedCosineSimilarity512(ByteSequence<byte[]> baseOffsets, int clusterCount, ArrayVectorFloat partialSums, ArrayVectorFloat aMagnitude, float bMagnitude) {
         var sum = FloatVector.zero(FloatVector.SPECIES_512);
         var vaMagnitude = FloatVector.zero(FloatVector.SPECIES_512);
-        var baseOffsets = encoded.get();
         var partialSumsArray = partialSums.get();
         var aMagnitudeArray = aMagnitude.get();
 
         int[] convOffsets = scratchInt512.get();
-        int i = encoded.offset();
-        int length = encoded.length();
-        int limit = i + ByteVector.SPECIES_128.loopBound(length);
+        int i = 0;
+        int limit = i + ByteVector.SPECIES_128.loopBound(baseOffsets.length());
 
         var scale = IntVector.zero(IntVector.SPECIES_512).addIndex(clusterCount);
 
         for (; i < limit; i += ByteVector.SPECIES_128.length()) {
 
-            ByteVector.fromArray(ByteVector.SPECIES_128, baseOffsets, i)
+            ByteVector.fromArray(ByteVector.SPECIES_128, baseOffsets.get(), i + baseOffsets.offset())
                     .convertShape(VectorOperators.B2I, IntVector.SPECIES_512, 0)
                     .lanewise(VectorOperators.AND, BYTE_TO_INT_MASK_512)
                     .reinterpretAsInts()
@@ -698,8 +696,8 @@ final class SimdOps {
         float sumResult = sum.reduceLanes(VectorOperators.ADD);
         float aMagnitudeResult = vaMagnitude.reduceLanes(VectorOperators.ADD);
 
-            for (; i < length; i++) {
-            int offset = clusterCount * i + Byte.toUnsignedInt(baseOffsets[i]);
+            for (; i < baseOffsets.length(); i++) {
+            int offset = clusterCount * i + Byte.toUnsignedInt(baseOffsets.get(i));
             sumResult += partialSumsArray[offset];
             aMagnitudeResult += aMagnitudeArray[offset];
         }
@@ -707,23 +705,21 @@ final class SimdOps {
         return (float) (sumResult / Math.sqrt(aMagnitudeResult * bMagnitude));
     }
 
-    public static float pqDecodedCosineSimilarity256(ByteSequence<byte[]> encoded, int clusterCount, ArrayVectorFloat partialSums, ArrayVectorFloat aMagnitude, float bMagnitude) {
+    public static float pqDecodedCosineSimilarity256(ByteSequence<byte[]> baseOffsets, int clusterCount, ArrayVectorFloat partialSums, ArrayVectorFloat aMagnitude, float bMagnitude) {
         var sum = FloatVector.zero(FloatVector.SPECIES_256);
         var vaMagnitude = FloatVector.zero(FloatVector.SPECIES_256);
-        var baseOffsets = encoded.get();
         var partialSumsArray = partialSums.get();
         var aMagnitudeArray = aMagnitude.get();
 
         int[] convOffsets = scratchInt256.get();
-        int i = encoded.offset();
-        int length = encoded.length();
-        int limit = i + ByteVector.SPECIES_64.loopBound(length);
+        int i = 0;
+        int limit = ByteVector.SPECIES_64.loopBound(baseOffsets.length());
 
         var scale = IntVector.zero(IntVector.SPECIES_256).addIndex(clusterCount);
 
         for (; i < limit; i += ByteVector.SPECIES_64.length()) {
 
-            ByteVector.fromArray(ByteVector.SPECIES_64, baseOffsets, i)
+            ByteVector.fromArray(ByteVector.SPECIES_64, baseOffsets.get(), i + baseOffsets.offset())
                     .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0)
                     .lanewise(VectorOperators.AND, BYTE_TO_INT_MASK_256)
                     .reinterpretAsInts()
@@ -738,8 +734,8 @@ final class SimdOps {
         float sumResult = sum.reduceLanes(VectorOperators.ADD);
         float aMagnitudeResult = vaMagnitude.reduceLanes(VectorOperators.ADD);
 
-        for (; i < length; i++) {
-            int offset = clusterCount * i + Byte.toUnsignedInt(baseOffsets[i]);
+        for (; i < baseOffsets.length(); i++) {
+            int offset = clusterCount * i + Byte.toUnsignedInt(baseOffsets.get(i));
             sumResult += partialSumsArray[offset];
             aMagnitudeResult += aMagnitudeArray[offset];
         }


### PR DESCRIPTION
The current design stores the compressed vectors using a list of `ByteSequence` objects where each object represents a single vector. That costs us an overhead of 16 bytes for the `ByteSequence` wrapper class and 16 more bytes for the array in the `ArrayByteSequence`. In the case of a 128 dimension vector, we compress PQ down to 64 bytes, so the cost of the wrapper/array is 32 bytes out of the total 96 bytes, which is 33% of the total size. In cases where we have many of these vectors in memory, an extra 33% is quite large.

This PR proposes removing the per-vector wrapper and opts for a more dense representation by

1. Storing the vectors in an array of ByteSequence references where the `ByteSequence` has as many vectors as it can possibly hold.
2. Introducing a `ByteSequence#slice` method to allow for getting a slice of the whole `ByteSequence`. This method is intended to be light weight.
3. Introduce `ArraySliceByteSequence` to store the offset and length information to simplify element retrieval.
4. Introducing a `ByteSequence#offset` method to be used in conjunction with the `get` method to ensure that the Panama and SimdOps methods do not need to perform an array copy when passing the array to Panama.
5. Added assertions in the native code when we call `get` on a `MemorySegmentByteSequence` since we're technically not passing the offset. FWIW, we could consider updating the c to take a `long` offset and a `long` length since those MemorySegments can exceed int length.

We also make some minor breaking changes to the `VectorCompression` interface to allow implementations to construct the `CompressedVectors` object directly. This change simplifies most usages of the `encodeAll` method.

This PR is a more invasive alternative to #369, which only removed one of the two wrappers. 

## Rejected alternatives

Before implementing the PR this way, I tried a few alternatives.

1. Use MemorySegment in the PQVectors to remove the chunking required because we can have more PQVector bytes than int max, which pushes us to store the `compressedVectors` field as a `ByteSequence[]` instead of a constant `ByteSequence`. Further, a MemorySegment would have allowed for a simpler API because of its support in the Panama API. However, this solution proved challenging due to compilation requirements and concerns about using a preview api (MemorySegment) in java 20.
2. Attempt to use a ByteBuffer instead of `ArraySliceByteSequence`. This is plausible, but really just comes down to API design preference. It felt a bit clunky to add it in. The main advantage is that if we add this, we can avoid the `offset` method on the `ByteSequence` interface, which might be convenient. One way we could add it is by making PQVectors know how to create a ByteBuffer wrapping a slice of the `compressedVectors` data.