### PR TITLE
Hand-unroll the SIMD dot product loop

### DIFF
--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/microbench/SimilarityBench.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/microbench/SimilarityBench.java
@@ -22,53 +22,57 @@ import io.github.jbellis.jvector.vector.types.VectorFloat;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
 @Warmup(iterations = 2, time = 5)
-@Measurement(iterations = 3, time = 10)
-@Fork(warmups = 1, value = 1, jvmArgsAppend = {"--add-modules=jdk.incubator.vector", "--enable-preview", "-Djvector.experimental.enable_native_vectorization=true"})
+@Measurement(iterations = 3, time = 5)
+@Fork(value = 1, jvmArgsAppend = {"--add-modules=jdk.incubator.vector", "--enable-preview", "-Djvector.experimental.enable_native_vectorization=true"})
+@State(Scope.Thread)
 public class SimilarityBench {
 
-    static VectorFloat<?> A_4 = TestUtil.randomVector(new Random(), 4);
-    static VectorFloat<?> B_4 = TestUtil.randomVector(new Random(), 4);
-    static VectorFloat<?> A_8 = TestUtil.randomVector(new Random(), 8);
-    static VectorFloat<?> B_8 = TestUtil.randomVector(new Random(), 8);
-    static VectorFloat<?> A_16 = TestUtil.randomVector(new Random(), 16);
-    static VectorFloat<?> B_16 = TestUtil.randomVector(new Random(), 16);
+    @Param({"4", "8", "16", "1024"})
+    int size = 1024;
 
+    VectorFloat<?> A, B;
 
-    static
-
-    @Benchmark
-    @BenchmarkMode(Mode.Throughput)
-    @Threads(8)
-    public void testDotProduct_4(Blackhole bh) {
-        bh.consume(VectorUtil.dotProduct(A_4, B_4));
+    @Setup(Level.Trial)
+    public void setUp()
+    {
+        A = TestUtil.randomVector(new Random(), size);
+        B = TestUtil.randomVector(new Random(), size);
     }
 
-    @Benchmark
     @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    @Benchmark
     @Threads(8)
-    public void testDotProduct_8(Blackhole bh) {
-        bh.consume(VectorUtil.dotProduct(A_8, B_8));
+    public void testDotProduct8(Blackhole bh) {
+        bh.consume(VectorUtil.dotProduct(A, B));
     }
 
 
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
     @Benchmark
-    @BenchmarkMode(Mode.Throughput)
-    @Threads(8)
-    public void testDotProduct_16(Blackhole bh) {
-        bh.consume(VectorUtil.dotProduct(A_16, B_16));
+    @Threads(1)
+    public void testDotProduct1(Blackhole bh) {
+        bh.consume(VectorUtil.dotProduct(A, B));
     }
-
-
-
 
     public static void main(String[] args) throws Exception {
         org.openjdk.jmh.Main.main(args);

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
@@ -211,17 +211,18 @@ final class SimdOps {
             return dotPreferred(va, vaoffset, vb, vboffset);
 
         FloatVector sum0 = FloatVector.zero(FloatVector.SPECIES_PREFERRED);
-        FloatVector sum1 = sum0;
         FloatVector sum2 = sum0;
-        FloatVector sum3 = sum0;
-        FloatVector a0, a1, b0, b1, a2, a3, b2, b3;
 
         int vectorLength = FloatVector.SPECIES_PREFERRED.length();
 
         // unrolled vector loop
-        if (length >= vectorLength * 8)
+        if (length >= vectorLength * 4)
         {
-            length -= vectorLength * 8;
+            FloatVector sum1 = sum0;
+            FloatVector sum3 = sum0;
+            FloatVector a0, a1, b0, b1, a2, a3, b2, b3;
+
+            length -= vectorLength * 4;
             // first read some of the vectors
             a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 0);
             b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 0);
@@ -229,129 +230,71 @@ final class SimdOps {
             b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 1);
             a2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 2);
             b2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 2);
+            sum0 = a0.fma(b0, sum0);
             a3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 3);
             b3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 3);
 
             while (length >= vectorLength * 8)
             {
                 length -= vectorLength * 8;
-                // in the main loop, interleave processing a vector with reading the next ones and only use after a few
-                // ops
-                sum0 = a0.fma(b0, sum0);
+                // In the main loop, interleave processing a vector with reading the next ones and only use after a few
+                // ops. Each set of 4 vectors has no dependency between them and can thus be executed in parallel.
+                sum1 = a1.fma(b1, sum1);
                 a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 4);
                 b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 4);
-                sum1 = a1.fma(b1, sum1);
+                sum2 = a2.fma(b2, sum2);
                 a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 5);
                 b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 5);
-                sum2 = a2.fma(b2, sum2);
+                sum3 = a3.fma(b3, sum3);
                 a2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 6);
                 b2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 6);
-                sum3 = a3.fma(b3, sum3);
+                sum0 = a0.fma(b0, sum0);
                 a3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 7);
                 b3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 7);
                 vaoffset += vectorLength * 8;
                 vboffset += vectorLength * 8;
-
-                sum0 = a0.fma(b0, sum0);
+                sum1 = a1.fma(b1, sum1);
                 a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 0);
                 b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 0);
-                sum1 = a1.fma(b1, sum1);
+                sum2 = a2.fma(b2, sum2);
                 a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 1);
                 b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 1);
-                sum2 = a2.fma(b2, sum2);
+                sum3 = a3.fma(b3, sum3);
                 a2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 2);
                 b2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 2);
-                sum3 = a3.fma(b3, sum3);
+                sum0 = a0.fma(b0, sum0);
                 a3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 3);
                 b3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 3);
             }
 
-            sum0 = a0.fma(b0, sum0);
-            a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 4);
-            b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 4);
-            sum1 = a1.fma(b1, sum1);
-            a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 5);
-            b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 5);
-            sum2 = a2.fma(b2, sum2);
-            sum0 = a0.fma(b0, sum0);
-            a2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 6);
-            b2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 6);
-            sum3 = a3.fma(b3, sum3);
-            sum1 = a1.fma(b1, sum1);
-            a3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 7);
-            b3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 7);
-
-            vaoffset += vectorLength * 8;
-            vboffset += vectorLength * 8;
-            sum2 = a2.fma(b2, sum2);
-            sum3 = a3.fma(b3, sum3);
-            sum0 = sum0.add(sum2);
-            sum1 = sum1.add(sum3);
-        }
-
-        if (length >= vectorLength * 4)
-        {
-            length -= vectorLength * 4;
-            a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 0);
-            b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 0);
-            a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 1);
-            b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 1);
-
-            while (length >= vectorLength * 4)
+            if (length >= vectorLength * 4)
             {
                 length -= vectorLength * 4;
-                sum0 = a0.fma(b0, sum0);
-                a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 2);
-                b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 2);
                 sum1 = a1.fma(b1, sum1);
-                a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 3);
-                b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 3);
+                a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 4);
+                b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 4);
+                sum2 = a2.fma(b2, sum2);
+                a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 5);
+                b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 5);
+                sum3 = a3.fma(b3, sum3);
+                a2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 6);
+                b2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 6);
+                sum0 = a0.fma(b0, sum0);
+                a3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 7);
+                b3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 7);
                 vaoffset += vectorLength * 4;
                 vboffset += vectorLength * 4;
-                sum0 = a0.fma(b0, sum0);
-                a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 0);
-                b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 0);
-                sum1 = a1.fma(b1, sum1);
-                a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 1);
-                b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 1);
             }
-            sum0 = a0.fma(b0, sum0);
-            a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 2);
-            b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 2);
+
             sum1 = a1.fma(b1, sum1);
-            a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 3);
-            b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 3);
+            sum0 = sum0.add(sum1);
             vaoffset += vectorLength * 4;
             vboffset += vectorLength * 4;
-            sum0 = a0.fma(b0, sum0);
-            sum1 = a1.fma(b1, sum1);
+            sum2 = a2.fma(b2, sum2);
+            sum3 = a3.fma(b3, sum3);
+            sum2 = sum2.add(sum3);
         }
 
-        if (length >= vectorLength * 2)
-        {
-            length -= vectorLength * 2;
-            a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 0);
-            b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 0);
-            a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 1);
-            b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 1);
-            vaoffset += vectorLength * 2;
-            vboffset += vectorLength * 2;
-            while (length >= vectorLength * 2)
-            {
-                length -= vectorLength * 2;
-                sum0 = a0.fma(b0, sum0);
-                a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 0);
-                b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 0);
-                sum1 = a1.fma(b1, sum1);
-                a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 1);
-                b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 1);
-                vaoffset += vectorLength * 2;
-                vboffset += vectorLength * 2;
-            }
-            sum0 = a0.fma(b0, sum0);
-            sum1 = a1.fma(b1, sum1);
-        }
-        sum0 = sum0.add(sum1);
 
         // Process the remaining few vectors
         while (length >= vectorLength) {
@@ -362,42 +305,16 @@ final class SimdOps {
             vboffset += vectorLength;
             sum0 = a.fma(b, sum0);
         }
+        sum0 = sum0.add(sum2);
 
         float resVec = sum0.reduceLanes(VectorOperators.ADD);
-        float res1 = 0;
-        float res0 = 0;
-
-        if (length >= 2)
-        {
-            length -= 2;
-            float a0f = va.get(vaoffset);
-            float b0f = vb.get(vboffset);
-            float a1f = va.get(vaoffset + 1);
-            float b1f = vb.get(vboffset + 1);
-            vaoffset += 2;
-            vboffset += 2;
-            while (length >= 2)
-            {
-                length -= 2;
-                res0 += a0f * b0f;
-                a0f = va.get(vaoffset);
-                b0f = vb.get(vboffset);
-                res1 += a1f * b1f;
-                a1f = va.get(vaoffset + 1);
-                b1f = vb.get(vboffset + 1);
-                vaoffset += 2;
-                vboffset += 2;
-            }
-            res0 += a0f * b0f;
-            res1 += a1f * b1f;
-            res0 += res1;
-        }
+        float resTail = 0;
 
         // Process the tail
         for (; length > 0; --length)
-            res0 += va.get(vaoffset++) * vb.get(vboffset++);
+            resTail += va.get(vaoffset++) * vb.get(vboffset++);
 
-        return resVec + res0;
+        return resVec + resTail;
     }
 
     static float cosineSimilarity(ArrayVectorFloat v1, ArrayVectorFloat v2) {

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
@@ -211,90 +211,40 @@ final class SimdOps {
             return dotPreferred(va, vaoffset, vb, vboffset);
 
         FloatVector sum0 = FloatVector.zero(FloatVector.SPECIES_PREFERRED);
-        FloatVector sum2 = sum0;
+        FloatVector sum1 = sum0;
+        FloatVector a0, a1, b0, b1;
 
         int vectorLength = FloatVector.SPECIES_PREFERRED.length();
 
-        // unrolled vector loop
-        if (length >= vectorLength * 4)
+        // Unrolled vector loop; for dot product from L1 cache, an unroll factor of 2 generally suffices.
+        // If we are going to be getting data that's further down the hierarchy but not fetched off disk/network,
+        // we might want to unroll further, e.g. to 8 (4 sets of a,b,sum with 3-ahead reads seems to work best).
+        if (length >= vectorLength * 2)
         {
-            FloatVector sum1 = sum0;
-            FloatVector sum3 = sum0;
-            FloatVector a0, a1, b0, b1, a2, a3, b2, b3;
-
-            length -= vectorLength * 4;
-            // first read some of the vectors
+            length -= vectorLength * 2;
             a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 0);
             b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 0);
             a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 1);
             b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 1);
-            a2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 2);
-            b2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 2);
-            sum0 = a0.fma(b0, sum0);
-            a3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 3);
-            b3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 3);
-
-            while (length >= vectorLength * 8)
+            vaoffset += vectorLength * 2;
+            vboffset += vectorLength * 2;
+            while (length >= vectorLength * 2)
             {
-                length -= vectorLength * 8;
-                // In the main loop, interleave processing a vector with reading the next ones and only use after a few
-                // ops. Each set of 4 vectors has no dependency between them and can thus be executed in parallel.
-                sum1 = a1.fma(b1, sum1);
-                a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 4);
-                b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 4);
-                sum2 = a2.fma(b2, sum2);
-                a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 5);
-                b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 5);
-                sum3 = a3.fma(b3, sum3);
-                a2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 6);
-                b2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 6);
+                // All instructions in the main loop have no dependencies between them and can be executed in parallel.
+                length -= vectorLength * 2;
                 sum0 = a0.fma(b0, sum0);
-                a3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 7);
-                b3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 7);
-                vaoffset += vectorLength * 8;
-                vboffset += vectorLength * 8;
-                sum1 = a1.fma(b1, sum1);
                 a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 0);
                 b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 0);
-                sum2 = a2.fma(b2, sum2);
+                sum1 = a1.fma(b1, sum1);
                 a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 1);
                 b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 1);
-                sum3 = a3.fma(b3, sum3);
-                a2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 2);
-                b2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 2);
-                sum0 = a0.fma(b0, sum0);
-                a3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 3);
-                b3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 3);
+                vaoffset += vectorLength * 2;
+                vboffset += vectorLength * 2;
             }
-
-            if (length >= vectorLength * 4)
-            {
-                length -= vectorLength * 4;
-                sum1 = a1.fma(b1, sum1);
-                a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 4);
-                b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 4);
-                sum2 = a2.fma(b2, sum2);
-                a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 5);
-                b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 5);
-                sum3 = a3.fma(b3, sum3);
-                a2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 6);
-                b2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 6);
-                sum0 = a0.fma(b0, sum0);
-                a3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 7);
-                b3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 7);
-                vaoffset += vectorLength * 4;
-                vboffset += vectorLength * 4;
-            }
-
+            sum0 = a0.fma(b0, sum0);
             sum1 = a1.fma(b1, sum1);
-            sum0 = sum0.add(sum1);
-            vaoffset += vectorLength * 4;
-            vboffset += vectorLength * 4;
-            sum2 = a2.fma(b2, sum2);
-            sum3 = a3.fma(b3, sum3);
-            sum2 = sum2.add(sum3);
         }
-
+        sum0 = sum0.add(sum1);
 
         // Process the remaining few vectors
         while (length >= vectorLength) {
@@ -305,7 +255,6 @@ final class SimdOps {
             vboffset += vectorLength;
             sum0 = a.fma(b, sum0);
         }
-        sum0 = sum0.add(sum2);
 
         float resVec = sum0.reduceLanes(VectorOperators.ADD);
         float resTail = 0;

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
@@ -216,7 +216,8 @@ final class SimdOps {
 
         int i = 0;
         // unrolled vector loop
-        if (length >= vectorLength * 4)
+        final int unrolledLength = vectorLength * 4;
+        if (length >= unrolledLength)
         {
             FloatVector sum1 = sum0;
             FloatVector sum2 = sum0;
@@ -227,11 +228,11 @@ final class SimdOps {
             b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + i + vectorLength * 0);
             a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + i + vectorLength * 1);
             b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + i + vectorLength * 1);
-            a2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + i + vectorLength * 2);
-            b2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + i + vectorLength * 2);
-            i += vectorLength * 4;
+            i += unrolledLength;
+            a2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + i - vectorLength * 2);
+            b2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + i - vectorLength * 2);
 
-            while (i + vectorLength * 4 <= length)
+            while (i + unrolledLength <= length)
             {
                 // in the main loop, interleave processing a vector with reading the next ones and only use after a few
                 // ops
@@ -244,10 +245,10 @@ final class SimdOps {
                 sum2 = a2.fma(b2, sum2);
                 a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + i + vectorLength * 1);
                 b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + i + vectorLength * 1);
+                i += unrolledLength;
                 sum3 = a3.fma(b3, sum3);
-                a2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + i + vectorLength * 2);
-                b2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + i + vectorLength * 2);
-                i += vectorLength * 4;
+                a2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + i - vectorLength * 2);
+                b2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + i - vectorLength * 2);
             }
 
             sum0 = a0.fma(b0, sum0);
@@ -262,9 +263,10 @@ final class SimdOps {
         }
 
         // Process the remaining few vectors
-        for (; i + vectorLength <= length; i += vectorLength) {
+        while (i + vectorLength <= length) {
             FloatVector a = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + i);
             FloatVector b = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + i);
+            i += vectorLength;
             sum0 = a.fma(b, sum0);
         }
 

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
@@ -211,73 +211,193 @@ final class SimdOps {
             return dotPreferred(va, vaoffset, vb, vboffset);
 
         FloatVector sum0 = FloatVector.zero(FloatVector.SPECIES_PREFERRED);
+        FloatVector sum1 = sum0;
+        FloatVector sum2 = sum0;
+        FloatVector sum3 = sum0;
+        FloatVector a0, a1, b0, b1, a2, a3, b2, b3;
 
         int vectorLength = FloatVector.SPECIES_PREFERRED.length();
 
-        int i = 0;
         // unrolled vector loop
-        final int unrolledLength = vectorLength * 4;
-        if (length >= unrolledLength)
+        if (length >= vectorLength * 8)
         {
-            FloatVector sum1 = sum0;
-            FloatVector sum2 = sum0;
-            FloatVector sum3 = sum0;
-            FloatVector a0, a1, b0, b1, a2, a3, b2, b3;
+            length -= vectorLength * 8;
             // first read some of the vectors
-            a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + i + vectorLength * 0);
-            b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + i + vectorLength * 0);
-            a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + i + vectorLength * 1);
-            b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + i + vectorLength * 1);
-            i += unrolledLength;
-            a2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + i - vectorLength * 2);
-            b2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + i - vectorLength * 2);
+            a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 0);
+            b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 0);
+            a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 1);
+            b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 1);
+            a2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 2);
+            b2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 2);
+            a3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 3);
+            b3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 3);
 
-            while (i + unrolledLength <= length)
+            while (length >= vectorLength * 8)
             {
+                length -= vectorLength * 8;
                 // in the main loop, interleave processing a vector with reading the next ones and only use after a few
                 // ops
                 sum0 = a0.fma(b0, sum0);
-                a3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + i - vectorLength * 1);
-                b3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + i - vectorLength * 1);
+                a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 4);
+                b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 4);
                 sum1 = a1.fma(b1, sum1);
-                a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + i + vectorLength * 0);
-                b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + i + vectorLength * 0);
+                a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 5);
+                b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 5);
                 sum2 = a2.fma(b2, sum2);
-                a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + i + vectorLength * 1);
-                b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + i + vectorLength * 1);
-                i += unrolledLength;
+                a2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 6);
+                b2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 6);
                 sum3 = a3.fma(b3, sum3);
-                a2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + i - vectorLength * 2);
-                b2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + i - vectorLength * 2);
+                a3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 7);
+                b3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 7);
+                vaoffset += vectorLength * 8;
+                vboffset += vectorLength * 8;
+
+                sum0 = a0.fma(b0, sum0);
+                a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 0);
+                b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 0);
+                sum1 = a1.fma(b1, sum1);
+                a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 1);
+                b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 1);
+                sum2 = a2.fma(b2, sum2);
+                a2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 2);
+                b2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 2);
+                sum3 = a3.fma(b3, sum3);
+                a3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 3);
+                b3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 3);
             }
 
             sum0 = a0.fma(b0, sum0);
-            a3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + i - vectorLength * 1);
-            b3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + i - vectorLength * 1);
+            a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 4);
+            b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 4);
             sum1 = a1.fma(b1, sum1);
+            a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 5);
+            b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 5);
             sum2 = a2.fma(b2, sum2);
-            sum1 = sum1.add(sum2);
+            sum0 = a0.fma(b0, sum0);
+            a2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 6);
+            b2 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 6);
             sum3 = a3.fma(b3, sum3);
-            sum0 = sum0.add(sum1);
-            sum0 = sum0.add(sum3);
+            sum1 = a1.fma(b1, sum1);
+            a3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 7);
+            b3 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 7);
+
+            vaoffset += vectorLength * 8;
+            vboffset += vectorLength * 8;
+            sum2 = a2.fma(b2, sum2);
+            sum3 = a3.fma(b3, sum3);
+            sum0 = sum0.add(sum2);
+            sum1 = sum1.add(sum3);
         }
 
+        if (length >= vectorLength * 4)
+        {
+            length -= vectorLength * 4;
+            a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 0);
+            b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 0);
+            a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 1);
+            b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 1);
+
+            while (length >= vectorLength * 4)
+            {
+                length -= vectorLength * 4;
+                sum0 = a0.fma(b0, sum0);
+                a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 2);
+                b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 2);
+                sum1 = a1.fma(b1, sum1);
+                a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 3);
+                b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 3);
+                vaoffset += vectorLength * 4;
+                vboffset += vectorLength * 4;
+                sum0 = a0.fma(b0, sum0);
+                a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 0);
+                b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 0);
+                sum1 = a1.fma(b1, sum1);
+                a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 1);
+                b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 1);
+            }
+            sum0 = a0.fma(b0, sum0);
+            a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 2);
+            b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 2);
+            sum1 = a1.fma(b1, sum1);
+            a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 3);
+            b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 3);
+            vaoffset += vectorLength * 4;
+            vboffset += vectorLength * 4;
+            sum0 = a0.fma(b0, sum0);
+            sum1 = a1.fma(b1, sum1);
+        }
+
+        if (length >= vectorLength * 2)
+        {
+            length -= vectorLength * 2;
+            a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 0);
+            b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 0);
+            a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 1);
+            b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 1);
+            vaoffset += vectorLength * 2;
+            vboffset += vectorLength * 2;
+            while (length >= vectorLength * 2)
+            {
+                length -= vectorLength * 2;
+                sum0 = a0.fma(b0, sum0);
+                a0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 0);
+                b0 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 0);
+                sum1 = a1.fma(b1, sum1);
+                a1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + vectorLength * 1);
+                b1 = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + vectorLength * 1);
+                vaoffset += vectorLength * 2;
+                vboffset += vectorLength * 2;
+            }
+            sum0 = a0.fma(b0, sum0);
+            sum1 = a1.fma(b1, sum1);
+        }
+        sum0 = sum0.add(sum1);
+
         // Process the remaining few vectors
-        while (i + vectorLength <= length) {
-            FloatVector a = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset + i);
-            FloatVector b = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset + i);
-            i += vectorLength;
+        while (length >= vectorLength) {
+            length -= vectorLength;
+            FloatVector a = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, va.get(), vaoffset);
+            FloatVector b = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, vb.get(), vboffset);
+            vaoffset += vectorLength;
+            vboffset += vectorLength;
             sum0 = a.fma(b, sum0);
         }
 
         float resVec = sum0.reduceLanes(VectorOperators.ADD);
+        float res1 = 0;
+        float res0 = 0;
 
-        float resTail = 0;
+        if (length >= 2)
+        {
+            length -= 2;
+            float a0f = va.get(vaoffset);
+            float b0f = vb.get(vboffset);
+            float a1f = va.get(vaoffset + 1);
+            float b1f = vb.get(vboffset + 1);
+            vaoffset += 2;
+            vboffset += 2;
+            while (length >= 2)
+            {
+                length -= 2;
+                res0 += a0f * b0f;
+                a0f = va.get(vaoffset);
+                b0f = vb.get(vboffset);
+                res1 += a1f * b1f;
+                a1f = va.get(vaoffset + 1);
+                b1f = vb.get(vboffset + 1);
+                vaoffset += 2;
+                vboffset += 2;
+            }
+            res0 += a0f * b0f;
+            res1 += a1f * b1f;
+            res0 += res1;
+        }
+
         // Process the tail
-        for (; i < length; ++i)
-            resTail += va.get(vaoffset + i) * vb.get(vboffset + i);
+        for (; length > 0; --length)
+            res0 += va.get(vaoffset++) * vb.get(vboffset++);
 
-        return resTail + resVec;
+        return resVec + res0;
     }
 
     static float cosineSimilarity(ArrayVectorFloat v1, ArrayVectorFloat v2) {


### PR DESCRIPTION
This removes some data dependencies and permit much greater internal parallelism for the code.

On my machine this reduces the single-threaded dot product time for 1024 floats by one third, from 111 ns to 74 ns.