### PR TITLE
Make ravv usage thread-safe

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/PQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/PQVectors.java
@@ -137,12 +137,14 @@ public abstract class PQVectors implements CompressedVectors {
         // Encode the vectors in parallel into the compressed data chunks
         // The changes are concurrent, but because they are coordinated and do not overlap, we can use parallel streams
         // and then we are guaranteed safe publication because we join the thread after completion.
+        var ravvCopy = ravv.threadLocalSupplier();
         simdExecutor.submit(() -> IntStream.range(0, ravv.size())
                         .parallel()
                         .forEach(ordinal -> {
                             // Retrieve the slice and mutate it.
+                            var localRavv = ravvCopy.get();
                             var slice = PQVectors.get(chunks, ordinal, vectorsPerChunk, pq.getSubspaceCount());
-                            var vector = ravv.getVector(ordinal);
+                            var vector = localRavv.getVector(ordinal);
                             if (vector != null)
                                 pq.encodeTo(vector, slice);
                             else


### PR DESCRIPTION
This resolves the issue that @jkni caught when reviewing #374. It renders the parallel vector accesses during "encodeAll" thread safe.