### PR TITLE
make example use index view

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The code:
         ReaderSupplier rs = ReaderSupplierFactor.open(indexPath);
         OnDiskGraphIndex index = OnDiskGraphIndex.load(rs);
         // measure our recall against the (exactly computed) ground truth
-        Function<VectorFloat<?>, SearchScoreProvider> sspFactory = q -> SearchScoreProvider.exact(q, VectorSimilarityFunction.EUCLIDEAN, ravv);
+        Function<VectorFloat<?>, SearchScoreProvider> sspFactory = q -> SearchScoreProvider.exact(q, VectorSimilarityFunction.EUCLIDEAN, index.getView());
         testRecall(index, queryVectors, groundTruth, sspFactory);
 ```
 

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
@@ -160,7 +160,7 @@ public class SiftSmall {
         try (ReaderSupplier rs = ReaderSupplierFactory.open(indexPath)) {
             OnDiskGraphIndex index = OnDiskGraphIndex.load(rs);
             // measure our recall against the (exactly computed) ground truth
-            Function<VectorFloat<?>, SearchScoreProvider> sspFactory = q -> SearchScoreProvider.exact(q, VectorSimilarityFunction.EUCLIDEAN, ravv);
+            Function<VectorFloat<?>, SearchScoreProvider> sspFactory = q -> SearchScoreProvider.exact(q, VectorSimilarityFunction.EUCLIDEAN, index.getView());
             testRecall(index, queryVectors, groundTruth, sspFactory);
         }
     }


### PR DESCRIPTION
### Description
I noticed in the SiftSmall examples that when we demo persisting and loading back from disk we are still using the original flat vectors accessor which seem a bit counter intuitive since we are expecting OnDiskGraphIndex to already have the node vector values included.
https://github.com/jbellis/jvector/blob/main/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java#L163

### Proposed Solution
So in the example line above, should we switch this line: (using `raav` )
```java
            Function<VectorFloat<?>, SearchScoreProvider> sspFactory = q -> SearchScoreProvider.exact(q, VectorSimilarityFunction.EUCLIDEAN, ravv);
```
To this (using the index view `index.getView()`):
```java
            Function<VectorFloat<?>, SearchScoreProvider> sspFactory = q -> SearchScoreProvider.exact(q, VectorSimilarityFunction.EUCLIDEAN, index.getView());
```