### PR TITLE
Add jmh benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ hdf5/
 
 ### aider
 .aider*
+
+# JMH generated files
+dependency-reduced-pom.xml

--- a/benchmarks-jmh/README.md
+++ b/benchmarks-jmh/README.md
@@ -1,0 +1,37 @@
+# JMH Benchmarks
+Micro benchmarks for jVector. While {@link Bench.java} is about recall, the JMH benchmarks
+are mostly targeting scalability and latency aspects.
+
+## Building and running the benchmark
+
+1. You can build and then run
+```shell
+mvn clean install
+java --enable-native-access=ALL-UNNAMED \
+  --add-modules=jdk.incubator.vector \
+  -XX:+HeapDumpOnOutOfMemoryError \
+  -Xmx14G -Djvector.experimental.enable_native_vectorization=true \
+  -jar benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar 
+```
+2. Build and run the benchmarks directly
+```shell
+mvn clean package -pl :benchmarks-jmh -am -DskipTests=true exec:exec@benchmark -Pjmh
+```
+3. Build and run a specific benchmark or use command line arguments
+```shell
+# Run only benchmarks containing "Sample" in their name
+mvn clean package -pl :benchmarks-jmh -am -DskipTests=true exec:exec@benchmark -Pjmh -DargLine=".*Sample.*"
+
+# Run with different parameters
+mvn clean package -pl :benchmarks-jmh -am -DskipTests=true exec:exec@benchmark -Pjmh -DargLine="-f 1 -wi 5 -i 3 .*Sample.*"
+```
+
+Common JMH command line options you can use in the configuration or command line:
+- `-f <num>` - Number of forks
+- `-wi <num>` - Number of warmup iterations
+- `-i <num>` - Number of measurement iterations
+- `-w <time>` - Warmup time per iteration
+- `-r <time>` - Measurement time per iteration
+- `-t <num>` - Number of threads
+- `-p <param>=<value>` - Benchmark parameters
+- `-prof <profiler>` - Add profiler

--- a/benchmarks-jmh/README.md
+++ b/benchmarks-jmh/README.md
@@ -6,24 +6,22 @@ are mostly targeting scalability and latency aspects.
 
 1. You can build and then run
 ```shell
-mvn clean install
+mvn clean install -DskipTests=true
 java --enable-native-access=ALL-UNNAMED \
   --add-modules=jdk.incubator.vector \
   -XX:+HeapDumpOnOutOfMemoryError \
   -Xmx14G -Djvector.experimental.enable_native_vectorization=true \
   -jar benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar 
 ```
-2. Build and run the benchmarks directly
-```shell
-mvn clean package -pl :benchmarks-jmh -am -DskipTests=true exec:exec@benchmark -Pjmh
-```
-3. Build and run a specific benchmark or use command line arguments
-```shell
-# Run only benchmarks containing "Sample" in their name
-mvn clean package -pl :benchmarks-jmh -am -DskipTests=true exec:exec@benchmark -Pjmh -DargLine=".*Sample.*"
 
-# Run with different parameters
-mvn clean package -pl :benchmarks-jmh -am -DskipTests=true exec:exec@benchmark -Pjmh -DargLine="-f 1 -wi 5 -i 3 .*Sample.*"
+You can add additional optional JMH arguments dynamically from command line. For example, to run the benchmarks with 4 forks, 5 warmup iterations, 5 measurement iterations, 2 threads, and 10 seconds warmup time per iteration, use the following command:
+```shell
+java --enable-native-access=ALL-UNNAMED \
+  --add-modules=jdk.incubator.vector \
+  -XX:+HeapDumpOnOutOfMemoryError \
+  -Xmx14G -Djvector.experimental.enable_native_vectorization=true \
+  -jar benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar \
+  -f 4 -wi 5 -i 5 -t 2 -w 10s
 ```
 
 Common JMH command line options you can use in the configuration or command line:

--- a/benchmarks-jmh/pom.xml
+++ b/benchmarks-jmh/pom.xml
@@ -96,43 +96,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>jmh</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <configuration>
-                            <skip>false</skip>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>benchmark</id>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>java</executable>
-                                    <arguments>
-                                        <argument>--enable-native-access=ALL-UNNAMED</argument>
-                                        <argument>--add-modules=jdk.incubator.vector</argument>
-                                        <argument>-XX:+HeapDumpOnOutOfMemoryError</argument>
-                                        <argument>-Xmx14G</argument>
-                                        <argument>-Djvector.experimental.enable_native_vectorization=true</argument>
-                                        <argument>-jar</argument>
-                                        <argument>${project.build.directory}/benchmarks-jmh-${project.version}.jar</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/benchmarks-jmh/pom.xml
+++ b/benchmarks-jmh/pom.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.jbellis</groupId>
+        <artifactId>jvector-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>benchmarks-jmh</artifactId>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>22</maven.compiler.release>
+        <jmh.version>1.37</jmh.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jvector-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.jbellis</groupId>
+            <artifactId>jvector-twenty</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.jbellis</groupId>
+            <artifactId>jvector-native</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!--Ensures that annotation processor is running during compilation-->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${jmh.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
+            <!-- Shade this so we can run as a standalone jar -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>jmh</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>benchmark</id>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>java</executable>
+                                    <arguments>
+                                        <argument>--enable-native-access=ALL-UNNAMED</argument>
+                                        <argument>--add-modules=jdk.incubator.vector</argument>
+                                        <argument>-XX:+HeapDumpOnOutOfMemoryError</argument>
+                                        <argument>-Xmx14G</argument>
+                                        <argument>-Djvector.experimental.enable_native_vectorization=true</argument>
+                                        <argument>-jar</argument>
+                                        <argument>${project.build.directory}/benchmarks-jmh-${project.version}.jar</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/benchmarks-jmh/pom.xml
+++ b/benchmarks-jmh/pom.xml
@@ -34,6 +34,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.github.jbellis</groupId>
+            <artifactId>jvector-examples</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
             <version>${jmh.version}</version>
@@ -43,6 +48,12 @@
             <artifactId>jmh-generator-annprocess</artifactId>
             <version>${jmh.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>2.24.3</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/RandomVectorsBenchmark.java
+++ b/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/RandomVectorsBenchmark.java
@@ -15,20 +15,83 @@
  */
 package io.github.jbellis.jvector.bench;
 
+import io.github.jbellis.jvector.example.SiftSmall;
+import io.github.jbellis.jvector.example.util.SiftLoader;
+import io.github.jbellis.jvector.graph.*;
+import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
+import io.github.jbellis.jvector.util.Bits;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
 import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
 @Fork(1)
-@Warmup(iterations = 3)
+@Warmup(iterations = 2)
 @Measurement(iterations = 5)
+@Threads(1)
 public class RandomVectorsBenchmark {
+    private static final Logger log = LoggerFactory.getLogger(RandomVectorsBenchmark.class);
+    private RandomAccessVectorValues ravv;
+    private ArrayList<VectorFloat<?>> baseVectors;
+    private ArrayList<VectorFloat<?>> queryVectors;
+    private ArrayList<Set<Integer>> groundTruth;
+    private GraphIndexBuilder graphIndexBuilder;
+    private GraphIndex graphIndex;
+    int originalDimension;
+
+    @Setup
+    public void setup() throws IOException {
+        var siftPath = "siftsmall";
+        baseVectors = SiftLoader.readFvecs(String.format("%s/siftsmall_base.fvecs", siftPath));
+        queryVectors = SiftLoader.readFvecs(String.format("%s/siftsmall_query.fvecs", siftPath));
+        groundTruth = SiftLoader.readIvecs(String.format("%s/siftsmall_groundtruth.ivecs", siftPath));
+        log.info("base vectors size: {}, query vectors size: {}, loaded, dimensions {}",
+                baseVectors.size(), queryVectors.size(), baseVectors.get(0).length());
+        originalDimension = baseVectors.get(0).length();
+        // wrap the raw vectors in a RandomAccessVectorValues
+        ravv = new ListRandomAccessVectorValues(baseVectors, originalDimension);
+
+        // score provider using the raw, in-memory vectors
+        BuildScoreProvider bsp = BuildScoreProvider.randomAccessScoreProvider(ravv, VectorSimilarityFunction.EUCLIDEAN);
+
+        graphIndexBuilder = new GraphIndexBuilder(bsp,
+                ravv.dimension(),
+                16, // graph degree
+                100, // construction search depth
+                1.2f, // allow degree overflow during construction by this factor
+                1.2f); // relax neighbor diversity requirement by this factor
+        graphIndex = graphIndexBuilder.build(ravv);
+        queryVector = SiftSmall.randomVector(originalDimension);
+    }
+
+    @TearDown
+    public void tearDown() throws IOException {
+        baseVectors.clear();
+        queryVectors.clear();
+        groundTruth.clear();
+        graphIndexBuilder.close();
+    }
 
     @Benchmark
-    public void measureSomething() {
+    public void testOnHeapWithRandomQueryVectors(Blackhole blackhole) throws IOException {
+        var queryVector = SiftSmall.randomVector(originalDimension);
         // Your benchmark code here
-        System.out.println("Hello World!");
+        var searchResult = GraphSearcher.search(queryVector,
+                10, // number of results
+                ravv, // vectors we're searching, used for scoring
+                VectorSimilarityFunction.EUCLIDEAN, // how to score
+                graphIndex,
+                Bits.ALL); // valid ordinals to consider
+        blackhole.consume(searchResult);
     }
 }

--- a/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/RandomVectorsBenchmark.java
+++ b/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/RandomVectorsBenchmark.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jbellis.jvector.bench;
+
+import org.openjdk.jmh.annotations.*;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Fork(1)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+public class RandomVectorsBenchmark {
+
+    @Benchmark
+    public void measureSomething() {
+        // Your benchmark code here
+        System.out.println("Hello World!");
+    }
+}

--- a/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/RandomVectorsBenchmark.java
+++ b/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/RandomVectorsBenchmark.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.jbellis.jvector.bench;
 
 import io.github.jbellis.jvector.example.SiftSmall;

--- a/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/RandomVectorsBenchmark.java
+++ b/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/RandomVectorsBenchmark.java
@@ -71,7 +71,6 @@ public class RandomVectorsBenchmark {
                 1.2f, // allow degree overflow during construction by this factor
                 1.2f); // relax neighbor diversity requirement by this factor
         graphIndex = graphIndexBuilder.build(ravv);
-        queryVector = SiftSmall.randomVector(originalDimension);
     }
 
     @TearDown

--- a/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/StaticSetVectorsBenchmark.java
+++ b/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/StaticSetVectorsBenchmark.java
@@ -1,13 +1,27 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.jbellis.jvector.bench;
 
 import io.github.jbellis.jvector.example.SiftSmall;
+import io.github.jbellis.jvector.example.util.SiftLoader;
 import io.github.jbellis.jvector.graph.*;
 import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
 import io.github.jbellis.jvector.util.Bits;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
-import io.github.jbellis.jvector.vector.VectorizationProvider;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
-import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 import org.slf4j.Logger;
@@ -15,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -24,37 +39,25 @@ import java.util.concurrent.TimeUnit;
 @Warmup(iterations = 2)
 @Measurement(iterations = 5)
 @Threads(1)
-public class RandomVectorsBenchmark {
-    private static final Logger log = LoggerFactory.getLogger(RandomVectorsBenchmark.class);
-    private static final VectorTypeSupport VECTOR_TYPE_SUPPORT = VectorizationProvider.getInstance().getVectorTypeSupport();
+public class StaticSetVectorsBenchmark {
+    private static final Logger log = LoggerFactory.getLogger(StaticSetVectorsBenchmark.class);
     private RandomAccessVectorValues ravv;
     private ArrayList<VectorFloat<?>> baseVectors;
     private ArrayList<VectorFloat<?>> queryVectors;
+    private ArrayList<Set<Integer>> groundTruth;
     private GraphIndexBuilder graphIndexBuilder;
     private GraphIndex graphIndex;
     int originalDimension;
-    @Param({"1000", "10000", "100000", "1000000"})
-    int numBaseVectors;
-    @Param({"10"})
-    int numQueryVectors;
 
     @Setup
     public void setup() throws IOException {
-        originalDimension = 128; // Example dimension, can be adjusted
-
-        baseVectors = new ArrayList<>(numBaseVectors);
-        queryVectors = new ArrayList<>(numQueryVectors);
-
-        for (int i = 0; i < numBaseVectors; i++) {
-            VectorFloat<?> vector = createRandomVector(originalDimension);
-            baseVectors.add(vector);
-        }
-
-        for (int i = 0; i < numQueryVectors; i++) {
-            VectorFloat<?> vector = createRandomVector(originalDimension);
-            queryVectors.add(vector);
-        }
-
+        var siftPath = "siftsmall";
+        baseVectors = SiftLoader.readFvecs(String.format("%s/siftsmall_base.fvecs", siftPath));
+        queryVectors = SiftLoader.readFvecs(String.format("%s/siftsmall_query.fvecs", siftPath));
+        groundTruth = SiftLoader.readIvecs(String.format("%s/siftsmall_groundtruth.ivecs", siftPath));
+        log.info("base vectors size: {}, query vectors size: {}, loaded, dimensions {}",
+                baseVectors.size(), queryVectors.size(), baseVectors.get(0).length());
+        originalDimension = baseVectors.get(0).length();
         // wrap the raw vectors in a RandomAccessVectorValues
         ravv = new ListRandomAccessVectorValues(baseVectors, originalDimension);
 
@@ -70,23 +73,16 @@ public class RandomVectorsBenchmark {
         graphIndex = graphIndexBuilder.build(ravv);
     }
 
-    private VectorFloat<?> createRandomVector(int dimension) {
-        VectorFloat<?> vector = VECTOR_TYPE_SUPPORT.createFloatVector(dimension);
-        for (int i = 0; i < dimension; i++) {
-            vector.set(i, (float) Math.random());
-        }
-        return vector;
-    }
-
     @TearDown
     public void tearDown() throws IOException {
         baseVectors.clear();
         queryVectors.clear();
+        groundTruth.clear();
         graphIndexBuilder.close();
     }
 
     @Benchmark
-    public void testOnHeapRandomVectors(Blackhole blackhole) {
+    public void testOnHeapWithRandomQueryVectors(Blackhole blackhole) throws IOException {
         var queryVector = SiftSmall.randomVector(originalDimension);
         // Your benchmark code here
         var searchResult = GraphSearcher.search(queryVector,

--- a/benchmarks-jmh/src/main/resources/log4j2.xml
+++ b/benchmarks-jmh/src/main/resources/log4j2.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Appenders>
+        <!-- Console Appender -->
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <!-- Root Logger -->
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <module>jvector-tests</module>
         <module>jvector-multirelease</module>
         <module>jvector-examples</module>
+        <module>benchmarks-jmh</module>
     </modules>
     <build>
         <resources>

--- a/rat-excludes.txt
+++ b/rat-excludes.txt
@@ -9,3 +9,4 @@ src/main/assembly/test-jar-with-dependencies.xml
 src/assembly/mrjar.xml
 src/assembly/sourcesjar.xml
 src/main/java/io/github/jbellis/jvector/vector/cnative/*
+src/main/resources/log4j2.xml


### PR DESCRIPTION
# Add JMH Benchmarking

## Overview
This PR introduces a dedicated JMH benchmarking module (`benchmark-jmh`) to provide basic microbenchmarking for performance measurements for jvector operations. The module enables systematic performance testing and comparison of variants of the vector search such as:
- Search OnHeap/OnDisk 
- Random datasets vs static datasets.
- Search latency increase with dataset size
- Compare different scorer implementations

## Changes
- Add new `benchmark-jmh` module
- Implement two sample JMH benchmarks for basic tests `RandomVectorsBenchmark` and `StaticSetVectorsBenchmark`
- Add logging configuration for benchmark execution
- Include benchmark documentation and usage instructions

## Implementation Details
- Uses JMH 1.37 for microbenchmarking with blackhole compiler settings
- Includes both throughput and average time measurements
- Implements proper warmup and measurement cycles

## Usage
```shell
mvn clean install
java --enable-native-access=ALL-UNNAMED \
  --add-modules=jdk.incubator.vector \
  -XX:+HeapDumpOnOutOfMemoryError \
  -Xmx14G -Djvector.experimental.enable_native_vectorization=true \
  -jar benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar 
```
### Output 
The output summary will look like this:
```shell
Benchmark                                                   (numBaseVectors)  (numQueryVectors)  Mode  Cnt   Score   Error  Units
RandomVectorsBenchmark.testOnHeapRandomVectors                          1000                 10  avgt    5   9.454 ± 0.329  ms/op
RandomVectorsBenchmark.testOnHeapRandomVectors                         10000                 10  avgt    5  12.852 ± 0.512  ms/op
RandomVectorsBenchmark.testOnHeapRandomVectors                        100000                 10  avgt    5  13.037 ± 0.352  ms/op
RandomVectorsBenchmark.testOnHeapRandomVectors                       1000000                 10  avgt    5  15.759 ± 0.610  ms/op
StaticSetVectorsBenchmark.testOnHeapWithRandomQueryVectors               N/A                N/A  avgt    5   8.253 ± 0.172  ms/op
```

The full output will look something like this:
```
WARNING: Using incubator modules: jdk.incubator.vector
# JMH version: 1.37
# VM version: JDK 23.0.2, OpenJDK 64-Bit Server VM, 23.0.2+7-58
# VM invoker: /Library/Java/JavaVirtualMachines/jdk-23.0.2.jdk/Contents/Home/bin/java
# VM options: --enable-native-access=ALL-UNNAMED --add-modules=jdk.incubator.vector -XX:+HeapDumpOnOutOfMemoryError -Xmx14G -Djvector.experimental.enable_native_vectorization=true
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 5 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors
# Parameters: (numBaseVectors = 1000, numQueryVectors = 10)

# Run progress: 0.00% complete, ETA 00:05:50
# Fork: 1 of 1
WARNING: Using incubator modules: jdk.incubator.vector
# Warmup Iteration   1: 2025-02-22T07:05:19.037924Z io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors-jmh-worker-1 INFO Starting configuration XmlConfiguration[location=jar:file:/Users/samuelherman/projects/jvector/benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar!/log4j2.xml, lastModified=2025-02-22T07:05:12.069Z]...
2025-02-22T07:05:19.044574Z io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors-jmh-worker-1 INFO Start watching for changes to jar:file:/Users/samuelherman/projects/jvector/benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar!/log4j2.xml every 0 seconds
2025-02-22T07:05:19.045170Z io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors-jmh-worker-1 INFO Configuration XmlConfiguration[location=jar:file:/Users/samuelherman/projects/jvector/benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar!/log4j2.xml, lastModified=2025-02-22T07:05:12.069Z] started.
2025-02-22T07:05:19.047856Z io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors-jmh-worker-1 INFO Stopping configuration org.apache.logging.log4j.core.config.DefaultConfiguration@4865f20c...
2025-02-22T07:05:19.048282Z io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors-jmh-worker-1 INFO Configuration org.apache.logging.log4j.core.config.DefaultConfiguration@4865f20c stopped.
Feb 21, 2025 11:05:19 PM io.github.jbellis.jvector.vector.VectorizationProvider lookup
WARNING: Native vector API was not enabled. Failed to load supporting native library.
Feb 21, 2025 11:05:19 PM io.github.jbellis.jvector.vector.PanamaVectorizationProvider <init>
INFO: Preferred f32 species is 128
Feb 21, 2025 11:05:19 PM io.github.jbellis.jvector.vector.VectorizationProvider lookup
INFO: Java incubating Vector API enabled. Using PanamaVectorizationProvider.
9.426 ms/op
# Warmup Iteration   2: 9.415 ms/op
Iteration   1: 9.379 ms/op
Iteration   2: 9.417 ms/op
Iteration   3: 9.526 ms/op
Iteration   4: 9.564 ms/op
Iteration   5: 9.384 ms/op


Result "io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors":
  9.454 ±(99.9%) 0.329 ms/op [Average]
  (min, avg, max) = (9.379, 9.454, 9.564), stdev = 0.085
  CI (99.9%): [9.125, 9.783] (assumes normal distribution)


# JMH version: 1.37
# VM version: JDK 23.0.2, OpenJDK 64-Bit Server VM, 23.0.2+7-58
# VM invoker: /Library/Java/JavaVirtualMachines/jdk-23.0.2.jdk/Contents/Home/bin/java
# VM options: --enable-native-access=ALL-UNNAMED --add-modules=jdk.incubator.vector -XX:+HeapDumpOnOutOfMemoryError -Xmx14G -Djvector.experimental.enable_native_vectorization=true
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 5 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors
# Parameters: (numBaseVectors = 10000, numQueryVectors = 10)

# Run progress: 20.00% complete, ETA 00:05:35
# Fork: 1 of 1
WARNING: Using incubator modules: jdk.incubator.vector
# Warmup Iteration   1: 2025-02-22T07:06:43.016487Z io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors-jmh-worker-1 INFO Starting configuration XmlConfiguration[location=jar:file:/Users/samuelherman/projects/jvector/benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar!/log4j2.xml, lastModified=2025-02-22T07:05:12.069Z]...
2025-02-22T07:06:43.026214Z io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors-jmh-worker-1 INFO Start watching for changes to jar:file:/Users/samuelherman/projects/jvector/benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar!/log4j2.xml every 0 seconds
2025-02-22T07:06:43.027019Z io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors-jmh-worker-1 INFO Configuration XmlConfiguration[location=jar:file:/Users/samuelherman/projects/jvector/benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar!/log4j2.xml, lastModified=2025-02-22T07:05:12.069Z] started.
2025-02-22T07:06:43.029484Z io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors-jmh-worker-1 INFO Stopping configuration org.apache.logging.log4j.core.config.DefaultConfiguration@4865f20c...
2025-02-22T07:06:43.030070Z io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors-jmh-worker-1 INFO Configuration org.apache.logging.log4j.core.config.DefaultConfiguration@4865f20c stopped.
Feb 21, 2025 11:06:43 PM io.github.jbellis.jvector.vector.VectorizationProvider lookup
WARNING: Native vector API was not enabled. Failed to load supporting native library.
Feb 21, 2025 11:06:43 PM io.github.jbellis.jvector.vector.PanamaVectorizationProvider <init>
INFO: Preferred f32 species is 128
Feb 21, 2025 11:06:43 PM io.github.jbellis.jvector.vector.VectorizationProvider lookup
INFO: Java incubating Vector API enabled. Using PanamaVectorizationProvider.
13.040 ms/op
# Warmup Iteration   2: 12.795 ms/op
Iteration   1: 13.074 ms/op
Iteration   2: 12.798 ms/op
Iteration   3: 12.746 ms/op
Iteration   4: 12.771 ms/op
Iteration   5: 12.870 ms/op


Result "io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors":
  12.852 ±(99.9%) 0.512 ms/op [Average]
  (min, avg, max) = (12.746, 12.852, 13.074), stdev = 0.133
  CI (99.9%): [12.340, 13.363] (assumes normal distribution)


# JMH version: 1.37
# VM version: JDK 23.0.2, OpenJDK 64-Bit Server VM, 23.0.2+7-58
# VM invoker: /Library/Java/JavaVirtualMachines/jdk-23.0.2.jdk/Contents/Home/bin/java
# VM options: --enable-native-access=ALL-UNNAMED --add-modules=jdk.incubator.vector -XX:+HeapDumpOnOutOfMemoryError -Xmx14G -Djvector.experimental.enable_native_vectorization=true
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 5 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors
# Parameters: (numBaseVectors = 100000, numQueryVectors = 10)

# Run progress: 40.00% complete, ETA 00:08:13
# Fork: 1 of 1
WARNING: Using incubator modules: jdk.incubator.vector
# Warmup Iteration   1: 2025-02-22T07:10:48.184211Z io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors-jmh-worker-1 INFO Starting configuration XmlConfiguration[location=jar:file:/Users/samuelherman/projects/jvector/benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar!/log4j2.xml, lastModified=2025-02-22T07:05:12.069Z]...
2025-02-22T07:10:48.189528Z io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors-jmh-worker-1 INFO Start watching for changes to jar:file:/Users/samuelherman/projects/jvector/benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar!/log4j2.xml every 0 seconds
2025-02-22T07:10:48.190082Z io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors-jmh-worker-1 INFO Configuration XmlConfiguration[location=jar:file:/Users/samuelherman/projects/jvector/benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar!/log4j2.xml, lastModified=2025-02-22T07:05:12.069Z] started.
2025-02-22T07:10:48.191953Z io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors-jmh-worker-1 INFO Stopping configuration org.apache.logging.log4j.core.config.DefaultConfiguration@4865f20c...
2025-02-22T07:10:48.192352Z io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors-jmh-worker-1 INFO Configuration org.apache.logging.log4j.core.config.DefaultConfiguration@4865f20c stopped.
Feb 21, 2025 11:10:48 PM io.github.jbellis.jvector.vector.VectorizationProvider lookup
WARNING: Native vector API was not enabled. Failed to load supporting native library.
Feb 21, 2025 11:10:48 PM io.github.jbellis.jvector.vector.PanamaVectorizationProvider <init>
INFO: Preferred f32 species is 128
Feb 21, 2025 11:10:48 PM io.github.jbellis.jvector.vector.VectorizationProvider lookup
INFO: Java incubating Vector API enabled. Using PanamaVectorizationProvider.
13.037 ms/op
# Warmup Iteration   2: 12.935 ms/op
Iteration   1: 13.127 ms/op
Iteration   2: 12.943 ms/op
Iteration   3: 13.040 ms/op
Iteration   4: 12.948 ms/op
Iteration   5: 13.129 ms/op


Result "io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors":
  13.037 ±(99.9%) 0.352 ms/op [Average]
  (min, avg, max) = (12.943, 13.037, 13.129), stdev = 0.091
  CI (99.9%): [12.685, 13.389] (assumes normal distribution)


# JMH version: 1.37
# VM version: JDK 23.0.2, OpenJDK 64-Bit Server VM, 23.0.2+7-58
# VM invoker: /Library/Java/JavaVirtualMachines/jdk-23.0.2.jdk/Contents/Home/bin/java
# VM options: --enable-native-access=ALL-UNNAMED --add-modules=jdk.incubator.vector -XX:+HeapDumpOnOutOfMemoryError -Xmx14G -Djvector.experimental.enable_native_vectorization=true
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 5 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors
# Parameters: (numBaseVectors = 1000000, numQueryVectors = 10)

# Run progress: 60.00% complete, ETA 00:24:03
# Fork: 1 of 1
WARNING: Using incubator modules: jdk.incubator.vector
# Warmup Iteration   1: 2025-02-22T07:41:24.577770Z io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors-jmh-worker-1 INFO Starting configuration XmlConfiguration[location=jar:file:/Users/samuelherman/projects/jvector/benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar!/log4j2.xml, lastModified=2025-02-22T07:05:12.069Z]...
2025-02-22T07:41:24.585937Z io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors-jmh-worker-1 INFO Start watching for changes to jar:file:/Users/samuelherman/projects/jvector/benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar!/log4j2.xml every 0 seconds
2025-02-22T07:41:24.586486Z io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors-jmh-worker-1 INFO Configuration XmlConfiguration[location=jar:file:/Users/samuelherman/projects/jvector/benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar!/log4j2.xml, lastModified=2025-02-22T07:05:12.069Z] started.
2025-02-22T07:41:24.588383Z io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors-jmh-worker-1 INFO Stopping configuration org.apache.logging.log4j.core.config.DefaultConfiguration@4865f20c...
2025-02-22T07:41:24.588705Z io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors-jmh-worker-1 INFO Configuration org.apache.logging.log4j.core.config.DefaultConfiguration@4865f20c stopped.
Feb 21, 2025 11:41:24 PM io.github.jbellis.jvector.vector.VectorizationProvider lookup
WARNING: Native vector API was not enabled. Failed to load supporting native library.
Feb 21, 2025 11:41:24 PM io.github.jbellis.jvector.vector.PanamaVectorizationProvider <init>
INFO: Preferred f32 species is 128
Feb 21, 2025 11:41:24 PM io.github.jbellis.jvector.vector.VectorizationProvider lookup
INFO: Java incubating Vector API enabled. Using PanamaVectorizationProvider.
15.937 ms/op
# Warmup Iteration   2: 15.460 ms/op
Iteration   1: 15.563 ms/op
Iteration   2: 15.842 ms/op
Iteration   3: 15.633 ms/op
Iteration   4: 15.804 ms/op
Iteration   5: 15.952 ms/op


Result "io.github.jbellis.jvector.bench.RandomVectorsBenchmark.testOnHeapRandomVectors":
  15.759 ±(99.9%) 0.610 ms/op [Average]
  (min, avg, max) = (15.563, 15.759, 15.952), stdev = 0.158
  CI (99.9%): [15.149, 16.369] (assumes normal distribution)


# JMH version: 1.37
# VM version: JDK 23.0.2, OpenJDK 64-Bit Server VM, 23.0.2+7-58
# VM invoker: /Library/Java/JavaVirtualMachines/jdk-23.0.2.jdk/Contents/Home/bin/java
# VM options: --enable-native-access=ALL-UNNAMED --add-modules=jdk.incubator.vector -XX:+HeapDumpOnOutOfMemoryError -Xmx14G -Djvector.experimental.enable_native_vectorization=true
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 5 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.github.jbellis.jvector.bench.StaticSetVectorsBenchmark.testOnHeapWithRandomQueryVectors

# Run progress: 80.00% complete, ETA 01:26:12
# Fork: 1 of 1
WARNING: Using incubator modules: jdk.incubator.vector
# Warmup Iteration   1: 2025-02-22T12:50:08.942348Z io.github.jbellis.jvector.bench.StaticSetVectorsBenchmark.testOnHeapWithRandomQueryVectors-jmh-worker-1 INFO Starting configuration XmlConfiguration[location=jar:file:/Users/samuelherman/projects/jvector/benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar!/log4j2.xml, lastModified=2025-02-22T07:05:12.069Z]...
2025-02-22T12:50:08.950436Z io.github.jbellis.jvector.bench.StaticSetVectorsBenchmark.testOnHeapWithRandomQueryVectors-jmh-worker-1 INFO Start watching for changes to jar:file:/Users/samuelherman/projects/jvector/benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar!/log4j2.xml every 0 seconds
2025-02-22T12:50:08.951460Z io.github.jbellis.jvector.bench.StaticSetVectorsBenchmark.testOnHeapWithRandomQueryVectors-jmh-worker-1 INFO Configuration XmlConfiguration[location=jar:file:/Users/samuelherman/projects/jvector/benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar!/log4j2.xml, lastModified=2025-02-22T07:05:12.069Z] started.
2025-02-22T12:50:08.956372Z io.github.jbellis.jvector.bench.StaticSetVectorsBenchmark.testOnHeapWithRandomQueryVectors-jmh-worker-1 INFO Stopping configuration org.apache.logging.log4j.core.config.DefaultConfiguration@5fb60c32...
2025-02-22T12:50:08.956917Z io.github.jbellis.jvector.bench.StaticSetVectorsBenchmark.testOnHeapWithRandomQueryVectors-jmh-worker-1 INFO Configuration org.apache.logging.log4j.core.config.DefaultConfiguration@5fb60c32 stopped.
Feb 22, 2025 4:50:08 AM io.github.jbellis.jvector.vector.VectorizationProvider lookup
WARNING: Native vector API was not enabled. Failed to load supporting native library.
Feb 22, 2025 4:50:09 AM io.github.jbellis.jvector.vector.PanamaVectorizationProvider <init>
INFO: Preferred f32 species is 128
Feb 22, 2025 4:50:09 AM io.github.jbellis.jvector.vector.VectorizationProvider lookup
INFO: Java incubating Vector API enabled. Using PanamaVectorizationProvider.
04:50:09.095 [io.github.jbellis.jvector.bench.StaticSetVectorsBenchmark.testOnHeapWithRandomQueryVectors-jmh-worker-1] INFO  io.github.jbellis.jvector.bench.StaticSetVectorsBenchmark - base vectors size: 10000, query vectors size: 100, loaded, dimensions 128
8.378 ms/op
# Warmup Iteration   2: 8.282 ms/op
Iteration   1: 8.274 ms/op
Iteration   2: 8.254 ms/op
Iteration   3: 8.181 ms/op
Iteration   4: 8.254 ms/op
Iteration   5: 8.301 ms/op


Result "io.github.jbellis.jvector.bench.StaticSetVectorsBenchmark.testOnHeapWithRandomQueryVectors":
  8.253 ±(99.9%) 0.172 ms/op [Average]
  (min, avg, max) = (8.181, 8.253, 8.301), stdev = 0.045
  CI (99.9%): [8.081, 8.425] (assumes normal distribution)


# Run complete. Total time: 05:46:25

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

NOTE: Current JVM experimentally supports Compiler Blackholes, and they are in use. Please exercise
extra caution when trusting the results, look into the generated code to check the benchmark still
works, and factor in a small probability of new VM bugs. Additionally, while comparisons between
different JVMs are already problematic, the performance difference caused by different Blackhole
modes can be very significant. Please make sure you use the consistent Blackhole mode for comparisons.

Benchmark                                                   (numBaseVectors)  (numQueryVectors)  Mode  Cnt   Score   Error  Units
RandomVectorsBenchmark.testOnHeapRandomVectors                          1000                 10  avgt    5   9.454 ± 0.329  ms/op
RandomVectorsBenchmark.testOnHeapRandomVectors                         10000                 10  avgt    5  12.852 ± 0.512  ms/op
RandomVectorsBenchmark.testOnHeapRandomVectors                        100000                 10  avgt    5  13.037 ± 0.352  ms/op
RandomVectorsBenchmark.testOnHeapRandomVectors                       1000000                 10  avgt    5  15.759 ± 0.610  ms/op
StaticSetVectorsBenchmark.testOnHeapWithRandomQueryVectors               N/A                N/A  avgt    5   8.253 ± 0.172  ms/op
```