### PR TITLE
Optimization for latency reduction in Product Quantization

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/KMeansPlusPlusClusterer.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/KMeansPlusPlusClusterer.java
@@ -215,7 +215,7 @@ public class KMeansPlusPlusClusterer {
             centroids.copyFrom(nextCentroid, 0, i * nextCentroid.length(), nextCentroid.length());
 
             // Update distances, but only if the new centroid provides a closer distance
-            newDistancesVector.zero();
+            // All entries of newDistancesVector is overwritten with the updated squareL2Distance value
             for (int j = 0; j < distancesLength; j++) {
                 newDistancesVector.set(j, squareL2Distance(points[j], nextCentroid));
             }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/KMeansPlusPlusClusterer.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/KMeansPlusPlusClusterer.java
@@ -181,26 +181,26 @@ public class KMeansPlusPlusClusterer {
 
         float[] distances = new float[points.length];
         Arrays.fill(distances, Float.MAX_VALUE);
+        VectorFloat<?> distancesVector = vectorTypeSupport.createFloatVector(distances);
+        int distancesLength = points.length;
 
         // Choose the first centroid randomly
         VectorFloat<?> firstCentroid = points[random.nextInt(points.length)];
         centroids.copyFrom(firstCentroid, 0, 0, firstCentroid.length());
+        VectorFloat<?> newDistancesVector = vectorTypeSupport.createFloatVector(points.length);
         for (int i = 0; i < points.length; i++) {
-            float distance1 = squareL2Distance(points[i], firstCentroid);
-            distances[i] = Math.min(distances[i], distance1);
+            newDistancesVector.set(i, squareL2Distance(points[i], firstCentroid));
         }
+        VectorUtil.minInPlace(distancesVector, newDistancesVector);
 
         // For each subsequent centroid
         for (int i = 1; i < k; i++) {
-            float totalDistance = 0;
-            for (float distance : distances) {
-                totalDistance += distance;
-            }
+            float totalDistance = VectorUtil.sum(distancesVector);
 
             float r = random.nextFloat() * totalDistance;
             int selectedIdx = -1;
-            for (int j = 0; j < distances.length; j++) {
-                r -= distances[j];
+            for (int j = 0; j < distancesLength; j++) {
+                r -= distancesVector.get(j);
                 if (r < 1e-6) {
                     selectedIdx = j;
                     break;
@@ -215,10 +215,11 @@ public class KMeansPlusPlusClusterer {
             centroids.copyFrom(nextCentroid, 0, i * nextCentroid.length(), nextCentroid.length());
 
             // Update distances, but only if the new centroid provides a closer distance
-            for (int j = 0; j < points.length; j++) {
-                float newDistance = squareL2Distance(points[j], nextCentroid);
-                distances[j] = Math.min(distances[j], newDistance);
+            newDistancesVector.zero();
+            for (int j = 0; j < distancesLength; j++) {
+                newDistancesVector.set(j, squareL2Distance(points[j], nextCentroid));
             }
+            VectorUtil.minInPlace(distancesVector, newDistancesVector);
         }
         assertFinite(centroids);
         return centroids;

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/DefaultVectorUtilSupport.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/DefaultVectorUtilSupport.java
@@ -541,4 +541,11 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
 
     return squaredSum;
   }
+
+  @Override
+  public void minInPlace(VectorFloat<?> v1, VectorFloat<?> v2) {
+   for (int i = 0; i < v1.length(); i++) {
+     v1.set(i, Math.min(v1.get(i), v2.get(i)));
+    }
+  }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/DefaultVectorUtilSupport.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/DefaultVectorUtilSupport.java
@@ -288,6 +288,13 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
   }
 
   @Override
+  public void minInPlace(VectorFloat<?> v1, VectorFloat<?> v2) {
+    for (int i = 0; i < v1.length(); i++) {
+      v1.set(i, Math.min(v1.get(i), v2.get(i)));
+    }
+  }
+
+  @Override
   public float assembleAndSum(VectorFloat<?> data, int dataBase, ByteSequence<?> baseOffsets) {
     float sum = 0f;
     for (int i = 0; i < baseOffsets.length(); i++) {
@@ -542,10 +549,4 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
     return squaredSum;
   }
 
-  @Override
-  public void minInPlace(VectorFloat<?> v1, VectorFloat<?> v2) {
-   for (int i = 0; i < v1.length(); i++) {
-     v1.set(i, Math.min(v1.get(i), v2.get(i)));
-    }
-  }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtil.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtil.java
@@ -158,6 +158,10 @@ public final class VectorUtil {
     return impl.sub(a, aOffset, b, bOffset, length);
   }
 
+  public static void minInPlace(VectorFloat<?> distances1, VectorFloat<?> distances2) {
+    impl.minInPlace(distances1, distances2);
+  }
+
   public static float assembleAndSum(VectorFloat<?> data, int dataBase, ByteSequence<?> dataOffsets) {
     return impl.assembleAndSum(data, dataBase, dataOffsets);
   }
@@ -239,7 +243,4 @@ public final class VectorUtil {
     return impl.nvqUniformLoss(vector, minValue, maxValue, nBits);
   }
 
-  public static void minInPlace(VectorFloat<?> distances1, VectorFloat<?> distances2) {
-    impl.minInPlace(distances1, distances2);
-  }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtil.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtil.java
@@ -238,4 +238,8 @@ public final class VectorUtil {
   public static float nvqUniformLoss(VectorFloat<?> vector, float minValue, float maxValue, int nBits) {
     return impl.nvqUniformLoss(vector, minValue, maxValue, nBits);
   }
+
+  public static void minInPlace(VectorFloat<?> distances1, VectorFloat<?> distances2) {
+    impl.minInPlace(distances1, distances2);
+  }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtilSupport.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtilSupport.java
@@ -82,6 +82,9 @@ public interface VectorUtilSupport {
   /** @return a - b, element-wise, starting at aOffset and bOffset respectively */
   VectorFloat<?> sub(VectorFloat<?> a, int aOffset, VectorFloat<?> b, int bOffset, int length);
 
+  /** Calculates the minimum value for every corresponding lane values in v1 and v2, in place (v1 will be modified) */
+  void minInPlace(VectorFloat<?> v1, VectorFloat<?> v2);
+
   /**
    * Calculates the sum of sparse points in a vector.
    * <p>
@@ -301,6 +304,4 @@ public interface VectorUtilSupport {
    */
   float nvqUniformLoss(VectorFloat<?> vector, float minValue, float maxValue, int nBits);
 
-  /** Calculates the minimum value for every corresponding lane values in v1 and v2, in place (v1 will be modified) */
-  void minInPlace(VectorFloat<?> v1, VectorFloat<?> v2);
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtilSupport.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtilSupport.java
@@ -300,4 +300,7 @@ public interface VectorUtilSupport {
    * @param nBits the number of bits per dimension
    */
   float nvqUniformLoss(VectorFloat<?> vector, float minValue, float maxValue, int nBits);
+
+  /** Calculates the minimum value for every corresponding lane values in v1 and v2, in place (v1 will be modified) */
+  void minInPlace(VectorFloat<?> v1, VectorFloat<?> v2);
 }

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/NativeVectorUtilSupport.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/NativeVectorUtilSupport.java
@@ -111,6 +111,11 @@ final class NativeVectorUtilSupport implements VectorUtilSupport
     }
 
     @Override
+    public void minInPlace(VectorFloat<?> v1, VectorFloat<?> v2) {
+        VectorSimdOps.minInPlace((MemorySegmentVectorFloat) v1, (MemorySegmentVectorFloat) v2);
+    }
+
+    @Override
     public float assembleAndSum(VectorFloat<?> data, int dataBase, ByteSequence<?> baseOffsets) {
         assert baseOffsets.offset() == 0 : "Base offsets are expected to have an offset of 0. Found: " + baseOffsets.offset();
         return NativeSimdOps.assemble_and_sum_f32_512(((MemorySegmentVectorFloat)data).get(), dataBase, ((MemorySegmentByteSequence)baseOffsets).get(), baseOffsets.length());
@@ -226,8 +231,4 @@ final class NativeVectorUtilSupport implements VectorUtilSupport
         return VectorSimdOps.nvqUniformLoss((MemorySegmentVectorFloat) vector, minValue, maxValue, nBits);
     }
 
-	@Override
-    public void minInPlace(VectorFloat<?> v1, VectorFloat<?> v2) {
-        VectorSimdOps.minInPlace((MemorySegmentVectorFloat) v1, (MemorySegmentVectorFloat) v2);
-    }
 }

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/NativeVectorUtilSupport.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/NativeVectorUtilSupport.java
@@ -225,4 +225,9 @@ final class NativeVectorUtilSupport implements VectorUtilSupport
     public float nvqUniformLoss(VectorFloat<?> vector, float minValue, float maxValue, int nBits) {
         return VectorSimdOps.nvqUniformLoss((MemorySegmentVectorFloat) vector, minValue, maxValue, nBits);
     }
+
+	@Override
+    public void minInPlace(VectorFloat<?> v1, VectorFloat<?> v2) {
+        VectorSimdOps.minInPlace((MemorySegmentVectorFloat) v1, (MemorySegmentVectorFloat) v2);
+    }
 }

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorUtilSupport.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorUtilSupport.java
@@ -77,6 +77,11 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         SimdOps.addInPlace((ArrayVectorFloat)v1, value);
     }
 
+	@Override
+    public void minInPlace(VectorFloat<?> v1, VectorFloat<?> v2) {
+        SimdOps.minInPlace((ArrayVectorFloat)v1, (ArrayVectorFloat)v2);
+    }
+
     @Override
     public void subInPlace(VectorFloat<?> v1, VectorFloat<?> v2) {
         SimdOps.subInPlace((ArrayVectorFloat) v1, (ArrayVectorFloat) v2);

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorUtilSupport.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorUtilSupport.java
@@ -77,11 +77,6 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         SimdOps.addInPlace((ArrayVectorFloat)v1, value);
     }
 
-	@Override
-    public void minInPlace(VectorFloat<?> v1, VectorFloat<?> v2) {
-        SimdOps.minInPlace((ArrayVectorFloat)v1, (ArrayVectorFloat)v2);
-    }
-
     @Override
     public void subInPlace(VectorFloat<?> v1, VectorFloat<?> v2) {
         SimdOps.subInPlace((ArrayVectorFloat) v1, (ArrayVectorFloat) v2);
@@ -108,6 +103,11 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     @Override
     public VectorFloat<?> sub(VectorFloat<?> a, int aOffset, VectorFloat<?> b, int bOffset, int length) {
         return SimdOps.sub((ArrayVectorFloat) a, aOffset, (ArrayVectorFloat) b, bOffset, length);
+    }
+
+    @Override
+    public void minInPlace(VectorFloat<?> v1, VectorFloat<?> v2) {
+        SimdOps.minInPlace((ArrayVectorFloat)v1, (ArrayVectorFloat)v2);
     }
 
     @Override

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
@@ -538,6 +538,26 @@ final class SimdOps {
         }
     }
 
+    static void minInPlace(ArrayVectorFloat v1, ArrayVectorFloat v2) {
+        if (v1.length() != v2.length()) {
+            throw new IllegalArgumentException("Vectors must have the same length");
+        }
+
+        int vectorizedLength = FloatVector.SPECIES_PREFERRED.loopBound(v1.length());
+
+        // Process the vectorized part
+        for (int i = 0; i < vectorizedLength; i += FloatVector.SPECIES_PREFERRED.length()) {
+            var a = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, v1.get(), i);
+            var b = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, v2.get(), i);
+            a.min(b).intoArray(v1.get(), i);
+        }
+
+        // Process the tail
+        for (int i = vectorizedLength; i < v1.length(); i++) {
+            v1.set(i,  Math.min(v1.get(i), v2.get(i)));
+        }
+    }
+
     static void subInPlace(ArrayVectorFloat v1, ArrayVectorFloat v2) {
         if (v1.length() != v2.length()) {
             throw new IllegalArgumentException("Vectors must have the same length");

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
@@ -538,26 +538,6 @@ final class SimdOps {
         }
     }
 
-    static void minInPlace(ArrayVectorFloat v1, ArrayVectorFloat v2) {
-        if (v1.length() != v2.length()) {
-            throw new IllegalArgumentException("Vectors must have the same length");
-        }
-
-        int vectorizedLength = FloatVector.SPECIES_PREFERRED.loopBound(v1.length());
-
-        // Process the vectorized part
-        for (int i = 0; i < vectorizedLength; i += FloatVector.SPECIES_PREFERRED.length()) {
-            var a = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, v1.get(), i);
-            var b = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, v2.get(), i);
-            a.min(b).intoArray(v1.get(), i);
-        }
-
-        // Process the tail
-        for (int i = vectorizedLength; i < v1.length(); i++) {
-            v1.set(i,  Math.min(v1.get(i), v2.get(i)));
-        }
-    }
-
     static void subInPlace(ArrayVectorFloat v1, ArrayVectorFloat v2) {
         if (v1.length() != v2.length()) {
             throw new IllegalArgumentException("Vectors must have the same length");
@@ -630,6 +610,26 @@ final class SimdOps {
         }
 
         return new ArrayVectorFloat(res);
+    }
+
+    static void minInPlace(ArrayVectorFloat v1, ArrayVectorFloat v2) {
+        if (v1.length() != v2.length()) {
+            throw new IllegalArgumentException("Vectors must have the same length");
+        }
+
+        int vectorizedLength = FloatVector.SPECIES_PREFERRED.loopBound(v1.length());
+
+        // Process the vectorized part
+        for (int i = 0; i < vectorizedLength; i += FloatVector.SPECIES_PREFERRED.length()) {
+            var a = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, v1.get(), i);
+            var b = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, v2.get(), i);
+            a.min(b).intoArray(v1.get(), i);
+        }
+
+        // Process the tail
+        for (int i = vectorizedLength; i < v1.length(); i++) {
+            v1.set(i,  Math.min(v1.get(i), v2.get(i)));
+        }
     }
 
     static float assembleAndSum(float[] data, int dataBase, ByteSequence<byte[]> baseOffsets) {


### PR DESCRIPTION
This PR optimizes the **io.github.jbellis.jvector.quantization.KMeansPlusPlusClusterer#chooseInitialCentroids** implementation using Java Vector API for the following cases.

1. Calculate minimums in a vectorized way instead of scalar fashion one at a time in loop.
2. Optimize scalar addition using vectorization. 

Tested the optimized code with the setup as below and observed latency reduction of ~6% in Product Quantization for ada002-100k dataset execution.

**Run Setup:**
**Jvector release used: 4.0.0-beta.1**
JDK used: 
**openjdk version "23.0.1" 2024-10-15**
OpenJDK Runtime Environment (build 23.0.1+11-39)
OpenJDK 64-Bit Server VM (build 23.0.1+11-39, mixed mode, sharing)

Socket 1 of m7i.metal-48xl machine used

To check the benefit of this optimization reasonably, following changes were done in Bench.java, PQParameters.java and Grid.java:
1. In buildCompression and searchCompression parameters, enabled only PQ parameters.
2. Disabled the caching for PQParameters.
3. Disabled the testConfiguration calls, to measure latency only for quantization and Index building. Observed Index building time is almost same in both baseline and optimized runs: 
    io/github/jbellis/jvector/example/Grid.java:141 --> /\*indexes.forEach((features, index) -> { ...});\*/
