### PR TITLE
add index construction benchmark

### DIFF
--- a/benchmarks-jmh/README.md
+++ b/benchmarks-jmh/README.md
@@ -33,3 +33,26 @@ Common JMH command line options you can use in the configuration or command line
 - `-t <num>` - Number of threads
 - `-p <param>=<value>` - Benchmark parameters
 - `-prof <profiler>` - Add profiler
+
+
+2. Focus on specific benchmarks
+
+For example in the below command lines we are going to run only `IndexConstructionWithStaticSetBenchmark`
+```shell
+mvn clean install -DskipTests=true
+BENCHMARK_NAME="IndexConstructionWithStaticSetBenchmark"
+java --enable-native-access=ALL-UNNAMED \
+  --add-modules=jdk.incubator.vector \
+  -XX:+HeapDumpOnOutOfMemoryError \
+  -Xmx14G -Djvector.experimental.enable_native_vectorization=true \
+  -jar benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar $BENCHMARK_NAME
+```
+
+If you want to rerun a specific benchmark without testing the entire grid of scenarios defined in the benchmark.
+You can just do the following to set M and beamWidth:
+```shell
+java -jar target/benchmarks.jar IndexConstructionWithStaticSetBenchmark -p M=32 -p beamWidth=100 
+```
+
+
+

--- a/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/IndexConstructionWithStaticSetBenchmark.java
+++ b/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/IndexConstructionWithStaticSetBenchmark.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jbellis.jvector.bench;
+
+import io.github.jbellis.jvector.example.SiftSmall;
+import io.github.jbellis.jvector.example.util.SiftLoader;
+import io.github.jbellis.jvector.graph.*;
+import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
+import io.github.jbellis.jvector.util.Bits;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Fork(1)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
+@Threads(1)
+public class IndexConstructionWithStaticSetBenchmark {
+    private static final Logger log = LoggerFactory.getLogger(IndexConstructionWithStaticSetBenchmark.class);
+    private RandomAccessVectorValues ravv;
+    private ArrayList<VectorFloat<?>> baseVectors;
+    private ArrayList<VectorFloat<?>> queryVectors;
+    private ArrayList<Set<Integer>> groundTruth;
+    private BuildScoreProvider bsp;
+    @Param({"16", "32", "64"})
+    private int M; // graph degree
+    @Param({"10", "100"})
+    private int beamWidth;
+    int originalDimension;
+
+    @Setup
+    public void setup() throws IOException {
+        var siftPath = "siftsmall";
+        baseVectors = SiftLoader.readFvecs(String.format("%s/siftsmall_base.fvecs", siftPath));
+        queryVectors = SiftLoader.readFvecs(String.format("%s/siftsmall_query.fvecs", siftPath));
+        groundTruth = SiftLoader.readIvecs(String.format("%s/siftsmall_groundtruth.ivecs", siftPath));
+        log.info("base vectors size: {}, query vectors size: {}, loaded, dimensions {}",
+                baseVectors.size(), queryVectors.size(), baseVectors.get(0).length());
+        originalDimension = baseVectors.get(0).length();
+        // wrap the raw vectors in a RandomAccessVectorValues
+        ravv = new ListRandomAccessVectorValues(baseVectors, originalDimension);
+
+        // score provider using the raw, in-memory vectors
+        bsp = BuildScoreProvider.randomAccessScoreProvider(ravv, VectorSimilarityFunction.EUCLIDEAN);
+    }
+
+    @TearDown
+    public void tearDown() throws IOException {
+        baseVectors.clear();
+        queryVectors.clear();
+        groundTruth.clear();
+    }
+
+    @Benchmark
+    public void buildIndexBenchmark(Blackhole blackhole) throws IOException {
+        // score provider using the raw, in-memory vectors
+        try (final var graphIndexBuilder = new GraphIndexBuilder(bsp, ravv.dimension(), M, beamWidth, 1.2f, 1.2f)) {
+            final var graphIndex = graphIndexBuilder.build(ravv);
+            blackhole.consume(graphIndex);
+        }
+    }
+}

--- a/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/PQBenchmark.java
+++ b/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/PQBenchmark.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jbellis.jvector.bench;
+
+import io.github.jbellis.jvector.example.util.SiftLoader;
+import io.github.jbellis.jvector.graph.GraphIndexBuilder;
+import io.github.jbellis.jvector.graph.ListRandomAccessVectorValues;
+import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
+import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
+import io.github.jbellis.jvector.quantization.ProductQuantization;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Fork(1)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
+@Threads(1)
+public class PQBenchmark {
+    private static final Logger log = LoggerFactory.getLogger(PQBenchmark.class);
+    private RandomAccessVectorValues ravv;
+    private ArrayList<VectorFloat<?>> baseVectors;
+    private ArrayList<VectorFloat<?>> queryVectors;
+    private ArrayList<Set<Integer>> groundTruth;
+    @Param({"16", "32", "64"})
+    private int M; // Number of subspaces
+    int originalDimension;
+
+    @Setup
+    public void setup() throws IOException {
+        var siftPath = "siftsmall";
+        baseVectors = SiftLoader.readFvecs(String.format("%s/siftsmall_base.fvecs", siftPath));
+        queryVectors = SiftLoader.readFvecs(String.format("%s/siftsmall_query.fvecs", siftPath));
+        groundTruth = SiftLoader.readIvecs(String.format("%s/siftsmall_groundtruth.ivecs", siftPath));
+        log.info("base vectors size: {}, query vectors size: {}, loaded, dimensions {}",
+                baseVectors.size(), queryVectors.size(), baseVectors.get(0).length());
+        originalDimension = baseVectors.get(0).length();
+        // wrap the raw vectors in a RandomAccessVectorValues
+        ravv = new ListRandomAccessVectorValues(baseVectors, originalDimension);
+    }
+
+    @TearDown
+    public void tearDown() throws IOException {
+        baseVectors.clear();
+        queryVectors.clear();
+        groundTruth.clear();
+    }
+
+    @Benchmark
+    public void productQuantizationComputeBenchmark(Blackhole blackhole) throws IOException {
+        // Compress the original vectors using PQ. this represents a compression ratio of 128 * 4 / 16 = 32x
+        ProductQuantization pq = ProductQuantization.compute(ravv,
+                M, // number of subspaces
+                256, // number of centroids per subspace
+                true); // center the dataset
+
+        blackhole.consume(pq);
+    }
+}


### PR DESCRIPTION
# Add Index Construction and PQ Benchmarks

## Overview
This PR introduces two new JMH benchmarks:
1. IndexConstuctionBenchmark - `OnHeapGraphIndex` construction performance using the SIFT dataset.
2. PQBenchmark - for PQ compute performance evaluation

### Configurable Parameters
IndexConstructionBenchmark:
- `M`: Graph degree (values: 16, 32, 64)
- `beamWidth`: Search beam width (values: 10, 100)

PQBenchmark:
- `M`: Number of subspaces (values: 16, 32, 64)

## Usage Example
```bash
mvn clean install -DskipTests=true
BENCHMARK_NAME="IndexConstructionWithStaticSetBenchmark"
java --enable-native-access=ALL-UNNAMED \
  --add-modules=jdk.incubator.vector \
  -XX:+HeapDumpOnOutOfMemoryError \
  -Xmx14G -Djvector.experimental.enable_native_vectorization=true \
  -jar benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar $BENCHMARK_NAME
```

## Expected Results

**IndexConstructionBenchmark**
Summary:
```shell
Benchmark                                                    (M)  (beamWidth)  Mode  Cnt      Score      Error  Units
IndexConstructionWithStaticSetBenchmark.buildIndexBenchmark   16           10  avgt    5   5662.825 ±  376.705  ms/op
IndexConstructionWithStaticSetBenchmark.buildIndexBenchmark   16          100  avgt    5  24502.426 ± 4603.127  ms/op
IndexConstructionWithStaticSetBenchmark.buildIndexBenchmark   32           10  avgt    5   6850.199 ± 1399.350  ms/op
IndexConstructionWithStaticSetBenchmark.buildIndexBenchmark   32          100  avgt    5  42590.718 ± 4610.805  ms/op
IndexConstructionWithStaticSetBenchmark.buildIndexBenchmark   64           10  avgt    5   9145.907 ± 3839.153  ms/op
IndexConstructionWithStaticSetBenchmark.buildIndexBenchmark   64          100  avgt    5  38560.479 ± 5420.277  ms/op
```

Output for each combination of `M, beamWidth`:
```shell
# Parameters: (M = 64, beamWidth = 100)
...
...
Result "io.github.jbellis.jvector.bench.IndexConstructionWithStaticSetBenchmark.buildIndexBenchmark":
  38560.479 ±(99.9%) 5420.277 ms/op [Average]
  (min, avg, max) = (36663.626, 38560.479, 39699.247), stdev = 1407.629
  CI (99.9%): [33140.202, 43980.756] (assumes normal distribution)
```

**PQBenchmark**
Summary:
```shell
Benchmark                                        (M)  Mode  Cnt      Score     Error  Units
PQBenchmark.productQuantizationComputeBenchmark   16  avgt    5  92248.292 ± 828.192  ms/op
PQBenchmark.productQuantizationComputeBenchmark   32  avgt    5    125.729 ±   1.435  ms/op
PQBenchmark.productQuantizationComputeBenchmark   64  avgt    5    193.587 ±   1.839  ms/op
```

Output for each combination `M`:
```shell
Result "io.github.jbellis.jvector.bench.PQBenchmark.productQuantizationComputeBenchmark":
  193.587 ±(99.9%) 1.839 ms/op [Average]
  (min, avg, max) = (193.130, 193.587, 194.371), stdev = 0.478
  CI (99.9%): [191.748, 195.426] (assumes normal distribution)
```

